### PR TITLE
Add support for Ubuntu-5.4.0-99.112 on Focal

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-kvm-introvirt (5.11.0-35.37-0.57.0~focal1) focal; urgency=medium
+kvm-introvirt (5.4.0-99.112-0.57.0~focal1) focal; urgency=medium
 
-  * Initial build for 5.11.0-35.37
+  * Initial build for 5.4.0-99.112
 
  -- Stephen Pape <srpape@gmail.com>  Tue, 31 Aug 2021 12:55:25 -0400

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,8 @@ Source: kvm-introvirt
 Section: devel
 Priority: optional
 Maintainer: Stephen Pape <srpape@gmail.com>
-Build-Depends: linux-modules-5.11.0-35-generic,
-               linux-headers-5.11.0-35-generic,
+Build-Depends: linux-modules-5.4.0-99-generic,
+               linux-headers-5.4.0-99-generic,
                bc,
                devscripts,
                quilt,
@@ -18,12 +18,12 @@ Homepage: https://github.com/IntroVirt/kvm-introvirt/
 Vcs-Browser: https://github.com/IntroVirt/kvm-introvirt/
 Vcs-Git: https://github.com/IntroVirt/kvm-introvirt.git
 
-Package: kvm-introvirt-5.11.0-35-generic
+Package: kvm-introvirt-5.4.0-99-generic
 Section: libs
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends},
-         linux-image-5.11.0-35-generic
+         linux-image-5.4.0-99-generic
 Multi-Arch: same
 Description: virtual machine introspection library
  Virtual machine introspection KVM driver
@@ -33,7 +33,7 @@ Section: libs
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends},
-         kvm-introvirt-5.11.0-35-generic (=${source:Version})
+         kvm-introvirt-5.4.0-99-generic (=${source:Version})
 Multi-Arch: same
 Description: virtual machine introspection library
  Virtual machine introspection KVM driver

--- a/patches/kvm-introvirt-56_3.patch
+++ b/patches/kvm-introvirt-56_3.patch
@@ -2,33 +2,40 @@ Index: kvm-introvirt/kernel/arch/x86/include/asm/kvm_host.h
 ===================================================================
 --- kvm-introvirt.orig/kernel/arch/x86/include/asm/kvm_host.h
 +++ kvm-introvirt/kernel/arch/x86/include/asm/kvm_host.h
-@@ -359,6 +359,7 @@ struct kvm_mmu {
+@@ -391,6 +391,7 @@ struct kvm_mmu {
  	int (*sync_page)(struct kvm_vcpu *vcpu,
  			 struct kvm_mmu_page *sp);
  	void (*invlpg)(struct kvm_vcpu *vcpu, gva_t gva, hpa_t root_hpa);
 +    int (*set_pte_perms)(struct kvm_vcpu *vcpu, u64 gpa, uint8_t perms, uint8_t* original_perms);
  	hpa_t root_hpa;
- 	gpa_t root_pgd;
+ 	gpa_t root_cr3;
  	union kvm_mmu_role mmu_role;
-@@ -1303,6 +1304,13 @@ struct kvm_x86_ops {
- 	int (*complete_emulated_msr)(struct kvm_vcpu *vcpu, int err);
+@@ -1029,6 +1030,7 @@ struct kvm_x86_ops {
+ 	void (*vcpu_put)(struct kvm_vcpu *vcpu);
  
- 	void (*vcpu_deliver_sipi_vector)(struct kvm_vcpu *vcpu, u8 vector);
+ 	void (*update_bp_intercept)(struct kvm_vcpu *vcpu);
++	void (*update_syscall_intercept)(struct kvm_vcpu *vcpu);
+ 	int (*get_msr)(struct kvm_vcpu *vcpu, struct msr_data *msr);
+ 	int (*set_msr)(struct kvm_vcpu *vcpu, struct msr_data *msr);
+ 	u64 (*get_segment_base)(struct kvm_vcpu *vcpu, int seg);
+@@ -1215,6 +1217,12 @@ struct kvm_x86_ops {
+ 
+ 	bool (*apic_init_signal_blocked)(struct kvm_vcpu *vcpu);
+ 	int (*enable_direct_tlbflush)(struct kvm_vcpu *vcpu);
 +
 +	/* IntroVirt patch */
 +	int (*set_cr_monitor)(struct kvm_vcpu *vcpu, int cr, int mode);
 +	int (*set_monitor_trap_flag)(struct kvm_vcpu *vcpu, bool enabled);
 +	int (*set_invlpg_monitor)(struct kvm_vcpu *vcpu, bool enabled);
 +	bool (*hap_permissions_allowed)(uint16_t perms);
-+	void (*update_syscall_intercept)(struct kvm_vcpu *vcpu);
  };
  
- struct kvm_x86_nested_ops {
+ struct kvm_arch_async_pf {
 Index: kvm-introvirt/kernel/arch/x86/kvm/emulate.c
 ===================================================================
 --- kvm-introvirt.orig/kernel/arch/x86/kvm/emulate.c
 +++ kvm-introvirt/kernel/arch/x86/kvm/emulate.c
-@@ -2832,6 +2832,69 @@ static int em_syscall(struct x86_emulate
+@@ -2842,6 +2842,69 @@ static int em_syscall(struct x86_emulate
  	return X86EMUL_CONTINUE;
  }
  
@@ -98,7 +105,7 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/emulate.c
  static int em_sysenter(struct x86_emulate_ctxt *ctxt)
  {
  	const struct x86_emulate_ops *ops = ctxt->ops;
-@@ -4753,7 +4816,7 @@ static const struct opcode twobyte_table
+@@ -4834,7 +4897,7 @@ static const struct opcode twobyte_table
  	/* 0x00 - 0x0F */
  	G(0, group6), GD(0, &group7), N, N,
  	N, I(ImplicitOps | EmulateOnUD, em_syscall),
@@ -121,11 +128,211 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/irq.c
  	if (!lapic_in_kernel(v))
  		return v->arch.interrupt.injected;
  
+Index: kvm-introvirt/kernel/arch/x86/kvm/mmu.c
+===================================================================
+--- kvm-introvirt.orig/kernel/arch/x86/kvm/mmu.c
++++ kvm-introvirt/kernel/arch/x86/kvm/mmu.c
+@@ -4280,8 +4280,8 @@ check_hugepage_cache_consistency(struct
+ 	return kvm_mtrr_check_gfn_range_consistency(vcpu, gfn, page_num);
+ }
+ 
+-static int tdp_page_fault(struct kvm_vcpu *vcpu, gpa_t gpa, u32 error_code,
+-			  bool prefault)
++static int __tdp_page_fault(struct kvm_vcpu *vcpu, gpa_t gpa, u32 error_code,
++			  bool prefault, bool guest_initiated)
+ {
+ 	kvm_pfn_t pfn;
+ 	int r;
+@@ -4296,6 +4296,36 @@ static int tdp_page_fault(struct kvm_vcp
+ 
+ 	MMU_WARN_ON(!VALID_PAGE(vcpu->arch.mmu->root_hpa));
+ 
++	/* If IntroVirt is hooking EPT faults, deliver here */
++	if (guest_initiated && kvm_is_mem_event_enabled(vcpu->kvm))
++	{
++		/* Look up the fault */
++		struct kvm *kvm = vcpu->kvm;
++		struct mem_access_entry * entry;
++		const u64 gfn = gpa >> PAGE_SHIFT;
++		int found_match = 0;
++
++		mutex_lock(&kvm->mem_access_table.mutex);
++
++		/* Search for the entry */
++		hash_for_each_possible(kvm->mem_access_table.table, entry, node, gfn)
++		{
++			/* Found a match, check requested permission */
++			if(entry->gfn == gfn) {
++				/* Match! */
++				found_match = true;
++				break;
++			}
++		}
++		mutex_unlock(&kvm->mem_access_table.mutex);
++
++		/* If we found a match, deliver it */
++		if (found_match) {
++			kvm_deliver_mem_event(vcpu, gpa, error_code);
++			return RET_PF_RETRY;
++		}
++	}
++
+ 	if (page_fault_handle_page_track(vcpu, error_code, gfn))
+ 		return RET_PF_EMULATE;
+ 
+@@ -4342,6 +4372,78 @@ out_unlock:
+ 	return r;
+ }
+ 
++static int tdp_page_fault(struct kvm_vcpu *vcpu, gpa_t gpa, u32 error_code,
++			  bool prefault)
++{
++	return __tdp_page_fault(vcpu, gpa, error_code, prefault, true);
++}
++
++
++static int tdp_set_pte_perms(struct kvm_vcpu *vcpu, u64 gfn, uint8_t perms, uint8_t* original_perms)
++{
++	struct kvm_shadow_walk_iterator iterator;
++	int result = -ESRCH;
++	u64 gpa = gfn << PAGE_SHIFT;
++	u64 spte = 0ull;
++
++	// Turn off any extra bits in the perms
++	perms &= (PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK);
++
++	// Validate the HAP permissions are allowed
++	if (unlikely(!kvm_x86_ops->hap_permissions_allowed(perms)))
++		return -EINVAL;
++
++	if (!VALID_PAGE(vcpu->arch.mmu->root_hpa))
++	{
++		result = kvm_mmu_load(vcpu);
++		if (unlikely(result))
++			return result;
++	}
++
++retry:
++	walk_shadow_page_lockless_begin(vcpu);
++
++	/* Find the page in the shadow tables */
++	for_each_shadow_entry_lockless(vcpu, gpa, iterator, spte)
++		if (!is_shadow_present_pte(spte) ||
++			iterator.level < PT_PAGE_TABLE_LEVEL)
++				{
++					/* The page is not present, so page it in for the guest process */
++					struct mm_struct* mm;
++					int r;
++
++					walk_shadow_page_lockless_end(vcpu);
++
++					/* Dirty hack */
++					/* hva_to_pfn() is hard-coded to current->mm */
++					mm = current->mm;
++					current->mm = vcpu->kvm->mm;
++					r = __tdp_page_fault(vcpu, gpa, 0, false, false);
++					current->mm = mm;
++					if (r)
++						return r;
++					goto retry;
++				}
++
++	// Try a few times to update the pte
++	result = -EBUSY;
++	do {
++		u64 new_spte = (spte & ~(PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK)) | perms;
++
++		if (original_perms != NULL)
++			*original_perms = (spte & (PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK));
++
++		if (cmpxchg64(iterator.sptep, spte, new_spte) == spte)
++		{
++			result = 0;
++			break;
++		}
++	} while(true);
++
++	walk_shadow_page_lockless_end(vcpu);
++	return result;
++}
++
+ static void nonpaging_init_context(struct kvm_vcpu *vcpu,
+ 				   struct kvm_mmu *context)
+ {
+@@ -5027,6 +5129,7 @@ static void init_kvm_tdp_mmu(struct kvm_
+ 
+ 	context->mmu_role.as_u64 = new_role.as_u64;
+ 	context->page_fault = tdp_page_fault;
++	context->set_pte_perms = tdp_set_pte_perms;
+ 	context->sync_page = nonpaging_sync_page;
+ 	context->invlpg = nonpaging_invlpg;
+ 	context->shadow_root_level = kvm_x86_ops->get_tdp_level(vcpu);
+@@ -5618,6 +5721,8 @@ void kvm_mmu_invlpg(struct kvm_vcpu *vcp
+ 
+ 	kvm_x86_ops->tlb_flush_gva(vcpu, gva);
+ 	++vcpu->stat.invlpg;
++
++	kvm_deliver_invlpg_event(vcpu, gva);
+ }
+ EXPORT_SYMBOL_GPL(kvm_mmu_invlpg);
+ 
+Index: kvm-introvirt/kernel/arch/x86/kvm/svm.c
+===================================================================
+--- kvm-introvirt.orig/kernel/arch/x86/kvm/svm.c
++++ kvm-introvirt/kernel/arch/x86/kvm/svm.c
+@@ -7241,6 +7241,26 @@ static bool svm_apic_init_signal_blocked
+ 		   (svm->vmcb->control.intercept & (1ULL << INTERCEPT_INIT));
+ }
+ 
++static int svm_set_cr_monitor(struct kvm_vcpu* vcpu, int cr, int mode)
++{
++	return -ENODEV;
++}
++
++static int svm_set_monitor_trap_flag(struct kvm_vcpu* vcpu, bool enabled)
++{
++	return -ENODEV;
++}
++
++static int svm_set_invlpg_monitor(struct kvm_vcpu *vcpu, bool enabled)
++{
++	return -ENODEV;
++}
++
++static bool svm_hap_permissions_allowed(uint16_t perms)
++{
++	return false;
++}
++
+ static struct kvm_x86_ops svm_x86_ops __ro_after_init = {
+ 	.cpu_has_kvm_support = has_svm,
+ 	.disabled_by_bios = is_disabled,
+@@ -7268,6 +7288,7 @@ static struct kvm_x86_ops svm_x86_ops __
+ 	.vcpu_unblocking = svm_vcpu_unblocking,
+ 
+ 	.update_bp_intercept = update_bp_intercept,
++	.update_syscall_intercept = update_bp_intercept, // TODO: Change when we have introspection on SVM
+ 	.get_msr_feature = svm_get_msr_feature,
+ 	.get_msr = svm_get_msr,
+ 	.set_msr = svm_set_msr,
+@@ -7380,6 +7401,12 @@ static struct kvm_x86_ops svm_x86_ops __
+ 	.need_emulation_on_page_fault = svm_need_emulation_on_page_fault,
+ 
+ 	.apic_init_signal_blocked = svm_apic_init_signal_blocked,
++
++	/* IntroVirt patch */
++	.set_cr_monitor = svm_set_cr_monitor,
++	.set_monitor_trap_flag = svm_set_monitor_trap_flag,
++	.set_invlpg_monitor = svm_set_invlpg_monitor,
++	.hap_permissions_allowed = svm_hap_permissions_allowed
+ };
+ 
+ static int __init svm_init(void)
 Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/capabilities.h
 ===================================================================
 --- kvm-introvirt.orig/kernel/arch/x86/kvm/vmx/capabilities.h
 +++ kvm-introvirt/kernel/arch/x86/kvm/vmx/capabilities.h
-@@ -66,6 +66,7 @@ extern struct vmcs_config vmcs_config;
+@@ -64,6 +64,7 @@ extern struct vmcs_config vmcs_config;
  struct vmx_capability {
  	u32 ept;
  	u32 vpid;
@@ -133,7 +340,7 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/capabilities.h
  };
  extern struct vmx_capability vmx_capability;
  
-@@ -114,6 +115,11 @@ static inline bool cpu_has_vmx_tpr_shado
+@@ -112,6 +113,11 @@ static inline bool cpu_has_vmx_tpr_shado
  	return vmcs_config.cpu_based_exec_ctrl & CPU_BASED_TPR_SHADOW;
  }
  
@@ -149,7 +356,7 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
 ===================================================================
 --- kvm-introvirt.orig/kernel/arch/x86/kvm/vmx/vmx.c
 +++ kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
-@@ -821,7 +821,7 @@ void update_exception_bitmap(struct kvm_
+@@ -760,7 +760,7 @@ void update_exception_bitmap(struct kvm_
  	 * We intercept those #GP and allow access to them anyway
  	 * as VMware does.
  	 */
@@ -158,7 +365,7 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
  		eb |= (1u << GP_VECTOR);
  	if ((vcpu->guest_debug &
  	     (KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP)) ==
-@@ -1035,6 +1035,11 @@ static bool update_transition_efer(struc
+@@ -961,6 +961,11 @@ static bool update_transition_efer(struc
  		ignore_bits &= ~(u64)EFER_SCE;
  #endif
  
@@ -170,7 +377,7 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
  	/*
  	 * On EPT, we can't emulate NX, so we must switch EFER atomically.
  	 * On CPUs that support "load IA32_EFER", always switch EFER
-@@ -1834,7 +1839,8 @@ static int vmx_get_msr(struct kvm_vcpu *
+@@ -1794,7 +1799,8 @@ static int vmx_get_msr(struct kvm_vcpu *
  		msr_info->data = to_vmx(vcpu)->spec_ctrl;
  		break;
  	case MSR_IA32_SYSENTER_CS:
@@ -180,7 +387,7 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
  		break;
  	case MSR_IA32_SYSENTER_EIP:
  		msr_info->data = vmcs_readl(GUEST_SYSENTER_EIP);
-@@ -2399,6 +2405,7 @@ static __init int setup_vmcs_config(stru
+@@ -2343,6 +2349,7 @@ static __init int setup_vmcs_config(stru
  
  	opt = CPU_BASED_TPR_SHADOW |
  	      CPU_BASED_USE_MSR_BITMAPS |
@@ -188,7 +395,7 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
  	      CPU_BASED_ACTIVATE_SECONDARY_CONTROLS;
  	if (adjust_vmx_controls(min, opt, MSR_IA32_VMX_PROCBASED_CTLS,
  				&_cpu_based_exec_control) < 0)
-@@ -2408,6 +2415,12 @@ static __init int setup_vmcs_config(stru
+@@ -2352,6 +2359,12 @@ static __init int setup_vmcs_config(stru
  		_cpu_based_exec_control &= ~CPU_BASED_CR8_LOAD_EXITING &
  					   ~CPU_BASED_CR8_STORE_EXITING;
  #endif
@@ -201,8 +408,8 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
  	if (_cpu_based_exec_control & CPU_BASED_ACTIVATE_SECONDARY_CONTROLS) {
  		min2 = 0;
  		opt2 = SECONDARY_EXEC_VIRTUALIZE_APIC_ACCESSES |
-@@ -2844,14 +2857,15 @@ int vmx_set_efer(struct kvm_vcpu *vcpu,
- 		return 0;
+@@ -2783,14 +2796,15 @@ void vmx_set_efer(struct kvm_vcpu *vcpu,
+ 		return;
  
  	vcpu->arch.efer = efer;
 +
@@ -216,9 +423,9 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
  	}
 +
  	setup_msrs(vmx);
- 	return 0;
  }
-@@ -4766,7 +4780,7 @@ static int handle_exception_nmi(struct k
+ 
+@@ -4627,7 +4641,7 @@ static int handle_exception_nmi(struct k
  		error_code = vmcs_read32(VM_EXIT_INTR_ERROR_CODE);
  
  	if (!vmx->rmode.vm86_active && is_gp_fault(intr_info)) {
@@ -227,7 +434,7 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
  
  		/*
  		 * VMware backdoor emulation on #GP interception only handles
-@@ -4842,6 +4856,24 @@ static int handle_exception_nmi(struct k
+@@ -4700,6 +4714,24 @@ static int handle_exception_nmi(struct k
  		rip = kvm_rip_read(vcpu);
  		kvm_run->debug.arch.pc = vmcs_readl(GUEST_CS_BASE) + rip;
  		kvm_run->debug.arch.exception = ex_no;
@@ -250,9 +457,9 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
 +		}
 +
  		break;
- 	case AC_VECTOR:
- 		if (vmx_guest_inject_ac(vcpu)) {
-@@ -4985,18 +5017,25 @@ static int handle_cr(struct kvm_vcpu *vc
+ 	default:
+ 		kvm_run->exit_reason = KVM_EXIT_EXCEPTION;
+@@ -4829,18 +4861,25 @@ static int handle_cr(struct kvm_vcpu *vc
  		trace_kvm_cr_write(cr, val);
  		switch (cr) {
  		case 0:
@@ -279,7 +486,7 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
  				err = kvm_set_cr8(vcpu, cr8);
  				ret = kvm_complete_insn_gp(vcpu, err);
  				if (lapic_in_kernel(vcpu))
-@@ -5025,11 +5064,13 @@ static int handle_cr(struct kvm_vcpu *vc
+@@ -4869,11 +4908,13 @@ static int handle_cr(struct kvm_vcpu *vc
  			val = kvm_read_cr3(vcpu);
  			kvm_register_write(vcpu, reg, val);
  			trace_kvm_cr_read(cr, val);
@@ -293,7 +500,32 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
  			return kvm_skip_emulated_instruction(vcpu);
  		}
  		break;
-@@ -5495,6 +5536,11 @@ static int handle_invalid_op(struct kvm_
+@@ -4984,6 +5025,16 @@ static void vmx_set_dr7(struct kvm_vcpu
+ 
+ static int handle_cpuid(struct kvm_vcpu *vcpu)
+ {
++	/*
++	 * It was difficult to find an event that is triggered on a reboot only once.
++	 * After we see RIP jumped to 0xFFF0, we wait for a CPUID instruction to
++	 * detect a "reboot" event.
++	 */
++	if (unlikely(vcpu->reboot_pending)) {
++		if (vcpu->vcpu_id == 0)
++			kvm_deliver_reboot_event(vcpu);
++		vcpu->reboot_pending = false;
++	}
+ 	return kvm_emulate_cpuid(vcpu);
+ }
+ 
+@@ -5199,6 +5250,7 @@ static int handle_ept_violation(struct k
+ 	       PFERR_GUEST_FINAL_MASK : PFERR_GUEST_PAGE_MASK;
+ 
+ 	vcpu->arch.exit_qualification = exit_qualification;
++
+ 	return kvm_mmu_page_fault(vcpu, gpa, error_code, NULL, 0);
+ }
+ 
+@@ -5386,6 +5438,11 @@ static int handle_invalid_op(struct kvm_
  
  static int handle_monitor_trap(struct kvm_vcpu *vcpu)
  {
@@ -305,18 +537,29 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
  	return 1;
  }
  
-@@ -6896,7 +6942,8 @@ static int vmx_create_vcpu(struct kvm_vc
- 	vmx_disable_intercept_for_msr(vcpu, MSR_GS_BASE, MSR_TYPE_RW);
- 	vmx_disable_intercept_for_msr(vcpu, MSR_KERNEL_GS_BASE, MSR_TYPE_RW);
- #endif
--	vmx_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_CS, MSR_TYPE_RW);
-+	/* IntroVirt patch */
-+	/* vmx_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_CS, MSR_TYPE_RW); */
- 	vmx_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_ESP, MSR_TYPE_RW);
- 	vmx_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_EIP, MSR_TYPE_RW);
- 	if (kvm_cstate_in_guest(vcpu->kvm)) {
-@@ -7592,6 +7639,102 @@ static int vmx_cpu_dirty_log_size(void)
- 	return enable_pml ? PML_ENTITY_NUM : 0;
+@@ -6737,7 +6794,8 @@ static struct kvm_vcpu *vmx_create_vcpu(
+ 	vmx_disable_intercept_for_msr(msr_bitmap, MSR_FS_BASE, MSR_TYPE_RW);
+ 	vmx_disable_intercept_for_msr(msr_bitmap, MSR_GS_BASE, MSR_TYPE_RW);
+ 	vmx_disable_intercept_for_msr(msr_bitmap, MSR_KERNEL_GS_BASE, MSR_TYPE_RW);
+-	vmx_disable_intercept_for_msr(msr_bitmap, MSR_IA32_SYSENTER_CS, MSR_TYPE_RW);
++	/* IntroVirt Patch */
++	/* vmx_disable_intercept_for_msr(msr_bitmap, MSR_IA32_SYSENTER_CS, MSR_TYPE_RW); */
+ 	vmx_disable_intercept_for_msr(msr_bitmap, MSR_IA32_SYSENTER_ESP, MSR_TYPE_RW);
+ 	vmx_disable_intercept_for_msr(msr_bitmap, MSR_IA32_SYSENTER_EIP, MSR_TYPE_RW);
+ 	if (kvm_cstate_in_guest(kvm)) {
+@@ -7668,7 +7726,9 @@ static __init int hardware_setup(void)
+ 	if (!cpu_has_vmx_tpr_shadow())
+ 		kvm_x86_ops->update_cr8_intercept = NULL;
+ 
+-	if (enable_ept && !cpu_has_vmx_ept_2m_page())
++	/* IntroVirt hack */
++	/* We want more granularity */
++	if ((enable_ept && !cpu_has_vmx_ept_2m_page()) || true)
+ 		kvm_disable_largepages();
+ 
+ #if IS_ENABLED(CONFIG_HYPERV)
+@@ -7782,6 +7842,102 @@ static __exit void hardware_unsetup(void
+ 	free_kvm_area();
  }
  
 +int vmx_set_cr_monitor(struct kvm_vcpu *vcpu, int cr, int mode)
@@ -415,55 +658,53 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/vmx/vmx.c
 +	return true;
 +}
 +
- static struct kvm_x86_ops vmx_x86_ops __initdata = {
- 	.hardware_unsetup = hardware_unsetup,
+ static struct kvm_x86_ops vmx_x86_ops __ro_after_init = {
+ 	.cpu_has_kvm_support = cpu_has_kvm_support,
+ 	.disabled_by_bios = vmx_disabled_by_bios,
+@@ -7806,6 +7962,7 @@ static struct kvm_x86_ops vmx_x86_ops __
+ 	.vcpu_put = vmx_vcpu_put,
  
-@@ -7725,6 +7868,13 @@ static struct kvm_x86_ops vmx_x86_ops __
- 	.cpu_dirty_log_size = vmx_cpu_dirty_log_size,
- 
- 	.vcpu_deliver_sipi_vector = kvm_vcpu_deliver_sipi_vector,
+ 	.update_bp_intercept = update_exception_bitmap,
++	.update_syscall_intercept = update_exception_bitmap,
+ 	.get_msr_feature = vmx_get_msr_feature,
+ 	.get_msr = vmx_get_msr,
+ 	.set_msr = vmx_set_msr,
+@@ -7934,6 +8091,12 @@ static struct kvm_x86_ops vmx_x86_ops __
+ 	.nested_get_evmcs_version = NULL,
+ 	.need_emulation_on_page_fault = vmx_need_emulation_on_page_fault,
+ 	.apic_init_signal_blocked = vmx_apic_init_signal_blocked,
 +
 +	/* IntroVirt patch */
-+	.update_syscall_intercept = update_exception_bitmap,
 +	.set_cr_monitor = vmx_set_cr_monitor,
 +	.set_monitor_trap_flag = vmx_set_monitor_trap_flag,
 +	.set_invlpg_monitor = vmx_set_invlpg_monitor,
-+	.hap_permissions_allowed = vmx_hap_permissions_allowed,
++	.hap_permissions_allowed = vmx_hap_permissions_allowed
  };
  
- static __init int hardware_setup(void)
-@@ -7820,12 +7970,15 @@ static __init int hardware_setup(void)
- 	if (enable_ept)
- 		vmx_enable_tdp();
- 
-+	/* IntroVirt hack for more EPT granularity */
- 	if (!enable_ept)
- 		ept_lpage_level = 0;
-+#if 0
- 	else if (cpu_has_vmx_ept_1g_page())
- 		ept_lpage_level = PG_LEVEL_1G;
- 	else if (cpu_has_vmx_ept_2m_page())
- 		ept_lpage_level = PG_LEVEL_2M;
-+#endif
- 	else
- 		ept_lpage_level = PG_LEVEL_4K;
- 	kvm_configure_mmu(enable_ept, vmx_get_max_tdp_level(), ept_lpage_level);
+ static void vmx_cleanup_l1d_flush(void)
 Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
 ===================================================================
 --- kvm-introvirt.orig/kernel/arch/x86/kvm/x86.c
 +++ kvm-introvirt/kernel/arch/x86/kvm/x86.c
-@@ -110,6 +110,10 @@ static void enter_smm(struct kvm_vcpu *v
+@@ -107,6 +107,7 @@ static void enter_smm(struct kvm_vcpu *v
  static void __kvm_set_rflags(struct kvm_vcpu *vcpu, unsigned long rflags);
  static void store_regs(struct kvm_vcpu *vcpu);
  static int sync_regs(struct kvm_vcpu *vcpu);
 +void kvm_arch_clear_mem_access(struct kvm* kvm);
-+
+ 
+ struct kvm_x86_ops *kvm_x86_ops __read_mostly;
+ EXPORT_SYMBOL_GPL(kvm_x86_ops);
+@@ -160,6 +161,9 @@ module_param(force_emulation_prefix, boo
+ int __read_mostly pi_inject_timer = -1;
+ module_param(pi_inject_timer, bint, S_IRUGO | S_IWUSR);
+ 
 +static void init_emulate_ctxt(struct kvm_vcpu *vcpu);
 +static void toggle_interruptibility(struct kvm_vcpu *vcpu, u32 mask);
++
+ #define KVM_NR_SHARED_MSRS 16
  
- struct kvm_x86_ops kvm_x86_ops __read_mostly;
- EXPORT_SYMBOL_GPL(kvm_x86_ops);
-@@ -1617,6 +1621,16 @@ static int __kvm_set_msr(struct kvm_vcpu
+ struct kvm_shared_msrs_global {
+@@ -1528,6 +1532,16 @@ static int __kvm_set_msr(struct kvm_vcpu
  		 * invokes 64-bit SYSENTER.
  		 */
  		data = get_canonical(data, vcpu_virt_addr_bits(vcpu));
@@ -480,17 +721,17 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
  	}
  
  	msr.data = data;
-@@ -3884,6 +3898,9 @@ int kvm_vm_ioctl_check_extension(struct
- 	case KVM_CAP_STEAL_TIME:
- 		r = sched_info_on();
- 		break;
+@@ -3321,7 +3335,8 @@ int kvm_vm_ioctl_check_extension(struct
+ 	case KVM_CAP_GET_MSR_FEATURES:
+ 	case KVM_CAP_MSR_PLATFORM_INFO:
+ 	case KVM_CAP_EXCEPTION_PAYLOAD:
+-		r = 1;
 +	case KVM_CAP_INTROSPECTION:
 +		r = KVM_INTROSPECTION_API_VERSION;
-+		break;
- 	default:
  		break;
- 	}
-@@ -4714,6 +4731,26 @@ static int kvm_vcpu_ioctl_enable_cap(str
+ 	case KVM_CAP_SYNC_REGS:
+ 		r = KVM_SYNC_X86_VALID_FIELDS;
+@@ -4179,6 +4194,26 @@ static int kvm_vcpu_ioctl_enable_cap(str
  	}
  }
  
@@ -503,13 +744,13 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
 +    vcpu->syscall_hook_enabled = enabled;
 +
 +	// Update the efer using the new 'syscall_hook_enabled' setting.
-+	kvm_x86_ops.set_efer(vcpu, vcpu->arch.efer);
++	kvm_x86_ops->set_efer(vcpu, vcpu->arch.efer);
 +
 +	// Update MSR_IA32_SYSENTER_CS
 +	kvm_set_msr(vcpu, MSR_IA32_SYSENTER_CS, vcpu->shadow_msr_ia32_sysenter_cs);
 +
 +	// Turn on or off #GP intercept
-+	kvm_x86_ops.update_syscall_intercept(vcpu);
++	kvm_x86_ops->update_syscall_intercept(vcpu);
 +done:
 +	return rc;
 +}
@@ -517,10 +758,10 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
  long kvm_arch_vcpu_ioctl(struct file *filp,
  			 unsigned int ioctl, unsigned long arg)
  {
-@@ -5071,6 +5108,107 @@ long kvm_arch_vcpu_ioctl(struct file *fi
- 	case KVM_GET_SUPPORTED_HV_CPUID:
- 		r = kvm_ioctl_get_supported_hv_cpuid(vcpu, argp);
+@@ -4550,6 +4585,107 @@ long kvm_arch_vcpu_ioctl(struct file *fi
+ 		r = 0;
  		break;
+ 	}
 +	case KVM_SET_CR_MONITOR: {
 +		struct kvm_cr_monitor cr_mon;
 +
@@ -528,15 +769,15 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
 +		if (copy_from_user(&cr_mon, argp, sizeof(cr_mon)))
 +			goto out;
 +
-+		r = kvm_x86_ops.set_cr_monitor(vcpu, cr_mon.cr, cr_mon.mode);
++		r = kvm_x86_ops->set_cr_monitor(vcpu, cr_mon.cr, cr_mon.mode);
 +		break;
 +	}
 +	case KVM_SET_INVLPG_HOOK: {
-+		r = kvm_x86_ops.set_invlpg_monitor(vcpu, arg);
++		r = kvm_x86_ops->set_invlpg_monitor(vcpu, arg);
 +		break;
 +	}
 +	case KVM_SET_MONITOR_TRAP_FLAG: {
-+		r = kvm_x86_ops.set_monitor_trap_flag(vcpu, arg);
++		r = kvm_x86_ops->set_monitor_trap_flag(vcpu, arg);
 +		break;
 +	}
 +	case KVM_SET_SYSCALL_HOOK: {
@@ -564,10 +805,10 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
 +	}
 +	case KVM_VCPU_INJECT_SYSENTER:
 +	case KVM_VCPU_INJECT_SYSCALL: {
-+		struct x86_emulate_ctxt *ctxt = vcpu->arch.emulate_ctxt;
++		struct x86_emulate_ctxt *ctxt = &vcpu->arch.emulate_ctxt;
 +		uint8_t insn[8];
 +		int insn_len = 0;
-+		unsigned long rflags = kvm_x86_ops.get_rflags(vcpu);
++		unsigned long rflags = kvm_x86_ops->get_rflags(vcpu);
 +		struct kvm_segment cs;
 +
 +		// Check CS for long mode
@@ -625,9 +866,9 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
  	default:
  		r = -EINVAL;
  	}
-@@ -5782,6 +5920,83 @@ set_pit2_out:
- 	case KVM_X86_SET_MSR_FILTER:
- 		r = kvm_vm_ioctl_set_msr_filter(kvm, argp);
+@@ -5202,6 +5338,83 @@ set_pit2_out:
+ 	case KVM_SET_PMU_EVENT_FILTER:
+ 		r = kvm_vm_ioctl_set_pmu_event_filter(kvm, argp);
  		break;
 +	case KVM_SET_MEM_ACCESS_ENABLED: {
 +		kvm->mem_event_enabled = arg;
@@ -709,16 +950,16 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
  	default:
  		r = -ENOTTY;
  	}
-@@ -7380,6 +7595,8 @@ int x86_emulate_instruction(struct kvm_v
- 	struct x86_emulate_ctxt *ctxt = vcpu->arch.emulate_ctxt;
+@@ -6717,6 +6930,8 @@ int x86_emulate_instruction(struct kvm_v
+ 	struct x86_emulate_ctxt *ctxt = &vcpu->arch.emulate_ctxt;
  	bool writeback = true;
- 	bool write_fault_to_spt;
+ 	bool write_fault_to_spt = vcpu->arch.write_fault_to_shadow_pgtable;
 +	bool sysret = false;
 +	bool sysexit = false;
  
- 	if (unlikely(!kvm_x86_ops.can_emulate_instruction(vcpu, insn, insn_len)))
- 		return 1;
-@@ -7437,10 +7654,54 @@ int x86_emulate_instruction(struct kvm_v
+ 	vcpu->arch.l1tf_flush_l1d = true;
+ 
+@@ -6775,10 +6990,54 @@ int x86_emulate_instruction(struct kvm_v
  		}
  	}
  
@@ -777,7 +1018,7 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
  	}
  
  	/*
-@@ -7463,6 +7724,7 @@ int x86_emulate_instruction(struct kvm_v
+@@ -6801,6 +7060,7 @@ int x86_emulate_instruction(struct kvm_v
  	if (vcpu->arch.emulate_regs_need_sync_from_vcpu) {
  		vcpu->arch.emulate_regs_need_sync_from_vcpu = false;
  		emulator_invalidate_register_cache(ctxt);
@@ -785,7 +1026,7 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
  	}
  
  restart:
-@@ -7543,6 +7805,12 @@ restart:
+@@ -6868,6 +7128,12 @@ restart:
  	} else
  		vcpu->arch.emulate_regs_need_sync_to_vcpu = true;
  
@@ -798,8 +1039,8 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
  	return r;
  }
  
-@@ -8074,6 +8342,40 @@ static int __kvm_vcpu_halt(struct kvm_vc
- 	}
+@@ -7364,6 +7630,40 @@ void kvm_arch_exit(void)
+ 	kmem_cache_destroy(x86_fpu_cache);
  }
  
 +void kvm_arch_clear_mem_access(struct kvm* kvm) {
@@ -825,21 +1066,21 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
 +{
 +	int i;
 +	for (i=0; i<=8; ++i) {
-+		kvm_x86_ops.set_cr_monitor(vcpu, i, 0);
++		kvm_x86_ops->set_cr_monitor(vcpu, i, 0);
 +	}
 +	kvm_arch_clear_mem_access(vcpu->kvm);
 +
 +	kvm_set_syscall_hook(vcpu, 0);
-+	kvm_x86_ops.set_monitor_trap_flag(vcpu, 0);
-+	kvm_x86_ops.set_invlpg_monitor(vcpu, 0);
++	kvm_x86_ops->set_monitor_trap_flag(vcpu, 0);
++	kvm_x86_ops->set_invlpg_monitor(vcpu, 0);
 +	vcpu->kvm->mem_event_enabled = 0;
 +	vcpu->vmcall_hook_enabled = 0;
 +}
 +
  int kvm_vcpu_halt(struct kvm_vcpu *vcpu)
  {
- 	return __kvm_vcpu_halt(vcpu, KVM_MP_STATE_HALTED, KVM_EXIT_HLT);
-@@ -8187,10 +8489,22 @@ int kvm_emulate_hypercall(struct kvm_vcp
+ 	++vcpu->stat.halt_exits;
+@@ -7472,10 +7772,22 @@ int kvm_emulate_hypercall(struct kvm_vcp
  	unsigned long nr, a0, a1, a2, a3, ret;
  	int op_64_bit;
  
@@ -863,7 +1104,7 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
  	a0 = kvm_rbx_read(vcpu);
  	a1 = kvm_rcx_read(vcpu);
  	a2 = kvm_rdx_read(vcpu);
-@@ -9234,12 +9548,33 @@ static int vcpu_run(struct kvm_vcpu *vcp
+@@ -8411,12 +8723,33 @@ static int vcpu_run(struct kvm_vcpu *vcp
  	vcpu->arch.l1tf_flush_l1d = true;
  
  	for (;;) {
@@ -897,8 +1138,8 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
  		if (r <= 0)
  			break;
  
-@@ -9761,6 +10096,12 @@ static int __set_sregs(struct kvm_vcpu *
- 	kvm_x86_ops.set_cr0(vcpu, sregs->cr0);
+@@ -8921,6 +9254,12 @@ static int __set_sregs(struct kvm_vcpu *
+ 	kvm_x86_ops->set_cr0(vcpu, sregs->cr0);
  	vcpu->arch.cr0 = sregs->cr0;
  
 +	if (kvm_rip_read(vcpu) == 0xfff0) {
@@ -908,9 +1149,17 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
 +	}
 +
  	mmu_reset_needed |= kvm_read_cr4(vcpu) != sregs->cr4;
- 	kvm_x86_ops.set_cr4(vcpu, sregs->cr4);
+ 	cpuid_update_needed |= ((kvm_read_cr4(vcpu) ^ sregs->cr4) &
+ 				(X86_CR4_OSXSAVE | X86_CR4_PKE));
+@@ -9168,6 +9507,7 @@ void kvm_arch_vcpu_free(struct kvm_vcpu
+ 	kvmclock_reset(vcpu);
  
-@@ -11362,6 +11703,206 @@ int kvm_spec_ctrl_test_value(u64 value)
+ 	kvm_x86_ops->vcpu_free(vcpu);
++
+ 	free_cpumask_var(wbinvd_dirty_mask);
+ }
+ 
+@@ -10403,6 +10743,207 @@ int kvm_spec_ctrl_test_value(u64 value)
  }
  EXPORT_SYMBOL_GPL(kvm_spec_ctrl_test_value);
  
@@ -1114,16 +1363,17 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.c
 +}
 +EXPORT_SYMBOL(kvm_deliver_shutdown_event);
 +
- void kvm_fixup_and_inject_pf_error(struct kvm_vcpu *vcpu, gva_t gva, u16 error_code)
- {
- 	struct x86_exception fault;
++
+ EXPORT_TRACEPOINT_SYMBOL_GPL(kvm_exit);
+ EXPORT_TRACEPOINT_SYMBOL_GPL(kvm_fast_mmio);
+ EXPORT_TRACEPOINT_SYMBOL_GPL(kvm_inj_virq);
 Index: kvm-introvirt/kernel/arch/x86/kvm/x86.h
 ===================================================================
 --- kvm-introvirt.orig/kernel/arch/x86/kvm/x86.h
 +++ kvm-introvirt/kernel/arch/x86/kvm/x86.h
-@@ -277,6 +277,29 @@ int x86_emulate_instruction(struct kvm_v
+@@ -289,6 +289,29 @@ bool kvm_vector_hashing_enabled(void);
+ int x86_emulate_instruction(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
  			    int emulation_type, void *insn, int insn_len);
- fastpath_t handle_fastpath_set_msr_irqoff(struct kvm_vcpu *vcpu);
  
 +static inline int kvm_is_cr_hooked(struct kvm_vcpu *vcpu, int cr, int mode)
 +{
@@ -1148,15 +1398,15 @@ Index: kvm-introvirt/kernel/arch/x86/kvm/x86.h
 +void kvm_deliver_reboot_event(struct kvm_vcpu *vcpu);
 +void kvm_deliver_mem_event(struct kvm_vcpu *vcpu, u64 gpa, u32 error_code);
 +
- extern u64 host_xcr0;
- extern u64 supported_xcr0;
- extern u64 host_xss;
+ #define KVM_SUPPORTED_XCR0     (XFEATURE_MASK_FP | XFEATURE_MASK_SSE \
+ 				| XFEATURE_MASK_YMM | XFEATURE_MASK_BNDREGS \
+ 				| XFEATURE_MASK_BNDCSR | XFEATURE_MASK_AVX512 \
 Index: kvm-introvirt/kernel/include/linux/kvm_host.h
 ===================================================================
 --- kvm-introvirt.orig/kernel/include/linux/kvm_host.h
 +++ kvm-introvirt/kernel/include/linux/kvm_host.h
 @@ -26,6 +26,7 @@
- #include <linux/rcuwait.h>
+ #include <linux/swait.h>
  #include <linux/refcount.h>
  #include <linux/nospec.h>
 +#include <linux/hashtable.h>
@@ -1188,10 +1438,10 @@ Index: kvm-introvirt/kernel/include/linux/kvm_host.h
 +	atomic_t pause_count;
 +
  	struct kvm_vcpu_arch arch;
- 	struct kvm_dirty_ring dirty_ring;
+ 	struct dentry *debugfs_dentry;
  };
-@@ -450,6 +471,17 @@ struct kvm_memslots {
- 	struct kvm_memory_slot memslots[];
+@@ -440,6 +461,17 @@ struct kvm_memslots {
+ 	int used_slots;
  };
  
 +struct mem_access_entry {
@@ -1208,10 +1458,10 @@ Index: kvm-introvirt/kernel/include/linux/kvm_host.h
  struct kvm {
  	spinlock_t mmu_lock;
  	struct mutex slots_lock;
-@@ -513,6 +545,11 @@ struct kvm {
+@@ -501,6 +533,11 @@ struct kvm {
+ 	struct srcu_struct srcu;
+ 	struct srcu_struct irq_srcu;
  	pid_t userspace_pid;
- 	unsigned int max_halt_poll_ns;
- 	u32 dirty_ring_size;
 +
 +	struct mem_access_table mem_access_table;
 +	atomic64_t event_id;
@@ -1220,7 +1470,7 @@ Index: kvm-introvirt/kernel/include/linux/kvm_host.h
  };
  
  #define kvm_err(fmt, ...) \
-@@ -602,6 +639,9 @@ void kvm_vcpu_destroy(struct kvm_vcpu *v
+@@ -591,6 +628,9 @@ void kvm_vcpu_uninit(struct kvm_vcpu *vc
  void vcpu_load(struct kvm_vcpu *vcpu);
  void vcpu_put(struct kvm_vcpu *vcpu);
  
@@ -1230,23 +1480,28 @@ Index: kvm-introvirt/kernel/include/linux/kvm_host.h
  #ifdef __KVM_HAVE_IOAPIC
  void kvm_arch_post_irq_ack_notifier_list_update(struct kvm *kvm);
  void kvm_arch_post_irq_routing_update(struct kvm *kvm);
-@@ -841,8 +881,11 @@ void kvm_arch_vcpu_blocking(struct kvm_v
- void kvm_arch_vcpu_unblocking(struct kvm_vcpu *vcpu);
- bool kvm_vcpu_wake_up(struct kvm_vcpu *vcpu);
+@@ -789,6 +829,7 @@ bool kvm_vcpu_wake_up(struct kvm_vcpu *v
  void kvm_vcpu_kick(struct kvm_vcpu *vcpu);
-+void kvm_arch_introspection_cleanup(struct kvm_vcpu *vcpu);
-+void kvm_deliver_shutdown_event(struct kvm_vcpu *vcpu);
  int kvm_vcpu_yield_to(struct kvm_vcpu *target);
  void kvm_vcpu_on_spin(struct kvm_vcpu *vcpu, bool usermode_vcpu_not_eligible);
 +void kvm_vcpu_check_pause(struct kvm_vcpu *vcpu); /* IntroVirt addition */
  
  void kvm_flush_remote_tlbs(struct kvm *kvm);
  void kvm_reload_remote_mmus(struct kvm *kvm);
+@@ -969,6 +1010,8 @@ void kvm_arch_sync_events(struct kvm *kv
+ 
+ int kvm_cpu_has_pending_timer(struct kvm_vcpu *vcpu);
+ void kvm_vcpu_kick(struct kvm_vcpu *vcpu);
++void kvm_arch_introspection_cleanup(struct kvm_vcpu *vcpu);
++void kvm_deliver_shutdown_event(struct kvm_vcpu *vcpu);
+ 
+ bool kvm_is_reserved_pfn(kvm_pfn_t pfn);
+ bool kvm_is_zone_device_pfn(kvm_pfn_t pfn);
 Index: kvm-introvirt/kernel/include/uapi/linux/kvm.h
 ===================================================================
 --- kvm-introvirt.orig/kernel/include/uapi/linux/kvm.h
 +++ kvm-introvirt/kernel/include/uapi/linux/kvm.h
-@@ -495,6 +495,20 @@ struct kvm_translation {
+@@ -462,6 +462,20 @@ struct kvm_translation {
  	__u8  pad[5];
  };
  
@@ -1267,7 +1522,7 @@ Index: kvm-introvirt/kernel/include/uapi/linux/kvm.h
  /* for KVM_S390_MEM_OP */
  struct kvm_s390_mem_op {
  	/* in */
-@@ -848,6 +862,133 @@ struct kvm_ppc_resize_hpt {
+@@ -814,6 +828,133 @@ struct kvm_ppc_resize_hpt {
  #define KVM_GET_MSR_FEATURE_INDEX_LIST    _IOWR(KVMIO, 0x0a, struct kvm_msr_list)
  
  /*
@@ -1405,22 +1660,23 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
 ===================================================================
 --- kvm-introvirt.orig/kernel/virt/kvm/kvm_main.c
 +++ kvm-introvirt/kernel/virt/kvm/kvm_main.c
-@@ -413,6 +413,14 @@ static void kvm_vcpu_init(struct kvm_vcp
- 	vcpu->preempted = false;
- 	vcpu->ready = false;
- 	preempt_notifier_init(&vcpu->preempt_notifier, &kvm_preempt_ops);
+@@ -353,6 +353,15 @@ int kvm_vcpu_init(struct kvm_vcpu *vcpu,
+ 	r = kvm_arch_vcpu_init(vcpu);
+ 	if (r < 0)
+ 		goto fail_free_run;
 +
-+	/* Introspection */
++	// Introspection
 +	mutex_init(&vcpu->introspection_event_mutex);
 +	init_waitqueue_head(&vcpu->introspection_event_completed_wait_queue);
 +	init_waitqueue_head(&vcpu->introspection_wait_queue);
 +	init_waitqueue_head(&vcpu->pause_wait_queue);
 +	vcpu->introspection_event = NULL;
 +	vcpu->reboot_pending = false;
- }
++
+ 	return 0;
  
- void kvm_vcpu_destroy(struct kvm_vcpu *vcpu)
-@@ -807,6 +815,9 @@ static struct kvm *kvm_create_vm(unsigne
+ fail_free_run:
+@@ -752,6 +761,9 @@ static struct kvm *kvm_create_vm(unsigne
  
  	preempt_notifier_inc();
  
@@ -1430,7 +1686,7 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
  	return kvm;
  
  out_err:
-@@ -923,6 +934,18 @@ static int kvm_vm_release(struct inode *
+@@ -856,6 +868,18 @@ static int kvm_vm_release(struct inode *
  	return 0;
  }
  
@@ -1448,8 +1704,8 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
 +
  /*
   * Allocation size is twice as large as the actual dirty bitmap size.
-  * See kvm_vm_ioctl_get_dirty_log() why this is needed.
-@@ -2840,6 +2863,9 @@ void kvm_vcpu_block(struct kvm_vcpu *vcp
+  * See x86's kvm_vm_ioctl_get_dirty_log() why this is needed.
+@@ -2512,6 +2536,9 @@ void kvm_vcpu_block(struct kvm_vcpu *vcp
  		if (kvm_vcpu_check_block(vcpu) < 0)
  			break;
  
@@ -1459,18 +1715,18 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
  		waited = true;
  		schedule();
  	}
-@@ -3109,16 +3135,81 @@ static int kvm_vcpu_release(struct inode
+@@ -2755,17 +2782,81 @@ static int kvm_vcpu_release(struct inode
  {
  	struct kvm_vcpu *vcpu = filp->private_data;
  
 +	if (vcpu->vcpu_id == 0)
 +		kvm_deliver_shutdown_event(vcpu);
 +
+ 	debugfs_remove_recursive(vcpu->debugfs_dentry);
  	kvm_put_kvm(vcpu->kvm);
  	return 0;
  }
  
-+
 +static int kvm_vcpu_introvirt_release(struct inode *inode, struct file *filp)
 +{
 +	struct kvm_vcpu *vcpu = filp->private_data;
@@ -1541,7 +1797,7 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
  };
  
  /*
-@@ -3132,6 +3223,11 @@ static int create_vcpu_fd(struct kvm_vcp
+@@ -2779,6 +2870,11 @@ static int create_vcpu_fd(struct kvm_vcp
  	return anon_inode_getfd(name, &kvm_vcpu_fops, vcpu, O_RDWR | O_CLOEXEC);
  }
  
@@ -1553,7 +1809,7 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
  static void kvm_create_vcpu_debugfs(struct kvm_vcpu *vcpu)
  {
  #ifdef __KVM_HAVE_ARCH_VCPU_DEBUGFS
-@@ -3248,6 +3344,35 @@ vcpu_decrement:
+@@ -2870,6 +2966,35 @@ vcpu_decrement:
  	return r;
  }
  
@@ -1589,7 +1845,7 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
  static int kvm_vcpu_ioctl_set_sigmask(struct kvm_vcpu *vcpu, sigset_t *sigset)
  {
  	if (sigset) {
-@@ -3259,6 +3384,31 @@ static int kvm_vcpu_ioctl_set_sigmask(st
+@@ -2881,6 +3006,31 @@ static int kvm_vcpu_ioctl_set_sigmask(st
  	return 0;
  }
  
@@ -1621,7 +1877,7 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
  static long kvm_vcpu_ioctl(struct file *filp,
  			   unsigned int ioctl, unsigned long arg)
  {
-@@ -3268,8 +3418,8 @@ static long kvm_vcpu_ioctl(struct file *
+@@ -2890,8 +3040,8 @@ static long kvm_vcpu_ioctl(struct file *
  	struct kvm_fpu *fpu = NULL;
  	struct kvm_sregs *kvm_sregs = NULL;
  
@@ -1632,7 +1888,7 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
  
  	if (unlikely(_IOC_TYPE(ioctl) != KVMIO))
  		return -EINVAL;
-@@ -3282,6 +3432,69 @@ static long kvm_vcpu_ioctl(struct file *
+@@ -2904,6 +3054,69 @@ static long kvm_vcpu_ioctl(struct file *
  	if (r != -ENOIOCTLCMD)
  		return r;
  
@@ -1702,7 +1958,19 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
  	if (mutex_lock_killable(&vcpu->mutex))
  		return -EINTR;
  	switch (ioctl) {
-@@ -3824,8 +4037,8 @@ static long kvm_vm_ioctl(struct file *fi
+@@ -2927,7 +3140,11 @@ static long kvm_vcpu_ioctl(struct file *
+ 				synchronize_rcu();
+ 			put_pid(oldpid);
+ 		}
++
++		//kvm_vcpu_check_for_pause(vcpu);
++
+ 		r = kvm_arch_vcpu_ioctl_run(vcpu, vcpu->run);
++
+ 		trace_kvm_userspace_exit(vcpu->run->exit_reason, r);
+ 		break;
+ 	}
+@@ -3363,8 +3580,8 @@ static long kvm_vm_ioctl(struct file *fi
  	void __user *argp = (void __user *)arg;
  	int r;
  
@@ -1713,9 +1981,9 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
  	switch (ioctl) {
  	case KVM_CREATE_VCPU:
  		r = kvm_vm_ioctl_create_vcpu(kvm, arg);
-@@ -3999,6 +4212,9 @@ static long kvm_vm_ioctl(struct file *fi
- 	case KVM_RESET_DIRTY_RINGS:
- 		r = kvm_vm_ioctl_reset_dirty_pages(kvm);
+@@ -3538,6 +3755,9 @@ out_free_irq_routing:
+ 	case KVM_CHECK_EXTENSION:
+ 		r = kvm_vm_ioctl_check_extension_generic(kvm, arg);
  		break;
 +	case KVM_ATTACH_VCPU:
 +		r = kvm_vm_ioctl_attach_vcpu(kvm, arg);
@@ -1723,7 +1991,7 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
  	default:
  		r = kvm_arch_vm_ioctl(filp, ioctl, arg);
  	}
-@@ -4047,11 +4263,100 @@ static long kvm_vm_compat_ioctl(struct f
+@@ -3586,11 +3806,100 @@ static long kvm_vm_compat_ioctl(struct f
  }
  #endif
  
@@ -1773,24 +2041,24 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
 +	/*
 +	 * Translate each address to page structs
 +	 */
-+	down_read(&kvm->mm->mmap_lock);
++	down_read(&kvm->mm->mmap_sem);
 +	for(i = 0; i < page_count; ++i) {
 +		int npages;
-+		npages = get_user_pages_remote(kvm->mm, addresses[i], 1, FOLL_WRITE,
++		npages = get_user_pages_remote(current, kvm->mm, addresses[i], 1, FOLL_WRITE,
 +				&pages[i],
 +				NULL, NULL);
 +
 +		if(unlikely(npages != 1)) {
-+			up_read(&kvm->mm->mmap_lock);
++			up_read(&kvm->mm->mmap_sem);
 +			return VM_FAULT_SIGBUS;
 +		}
 +	}
-+	up_read(&kvm->mm->mmap_lock);
++	up_read(&kvm->mm->mmap_sem);
 +
 +	/*
 +	 * Do the actual mapping
 +	 */
-+	down_write(&kvm->mm->mmap_lock);
++	down_write(&kvm->mm->mmap_sem);
 +	for(i = 0; i < page_count; ++i) {
 +		int r;
 +
@@ -1802,7 +2070,7 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
 +
 +		vma->vm_private_data = pages[i];
 +	}
-+	up_write(&kvm->mm->mmap_lock);
++	up_write(&kvm->mm->mmap_sem);
 +
 +	return 0;
 +}
@@ -1824,7 +2092,7 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
  };
  
  static int kvm_dev_ioctl_create_vm(unsigned long type)
-@@ -4100,10 +4405,39 @@ put_kvm:
+@@ -3639,10 +3948,39 @@ put_kvm:
  	return r;
  }
  
@@ -1864,7 +2132,7 @@ Index: kvm-introvirt/kernel/virt/kvm/kvm_main.c
  
  	switch (ioctl) {
  	case KVM_GET_API_VERSION:
-@@ -4133,6 +4467,48 @@ static long kvm_dev_ioctl(struct file *f
+@@ -3672,6 +4010,48 @@ static long kvm_dev_ioctl(struct file *f
  	case KVM_TRACE_DISABLE:
  		r = -EOPNOTSUPP;
  		break;


### PR DESCRIPTION
This patch bumps the support to Ubuntu-5.4.0-99.112 on Focal.

**Notes**:

HWE can be disabled on Focal in order to get the latest v5.4.0-x.x kernel.

To check if HWE is enabled (output if enabled, otherwise no output):
```
hwe-support-status
```

To disable HWE on focal:
```
sudo apt install linux-generic
sudo apt remove linux-{image,headers}-generic-hwe-20.04
```
