### PR TITLE
CI: Add initial support for Continuous Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI Tests
+
+on:
+  push:
+    paths-ignore: ['**.md']
+  pull_request:
+    paths-ignore: ['**.md']
+
+jobs:
+  Kernel_Module:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: kvm-introvirt
+      - name: Setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bc devscripts quilt git flex bison \
+            libssl-dev libelf-dev debhelper
+        shell: bash
+      - name: Validate Kernel Module Build
+        run: |
+          cd kvm-introvirt
+          ./configure
+          source ./.build_vars
+          sudo apt-get install -y linux-headers-${KERNEL_VERSION}${KERNEL_FLAVOR} \
+            linux-modules-${KERNEL_VERSION}${KERNEL_FLAVOR}
+          dpkg-buildpackage -us -uc -j
+        shell: bash
+      - name: Archive debian packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: kvm-introvirt
+          path: kvm-introvirt-*.deb

--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,4 @@ install: build
 	cp ./kernel/arch/x86/kvm/kvm.ko $(INSTALL_DIR)
 	cp ./kernel/arch/x86/kvm/kvm-intel.ko $(INSTALL_DIR)
 	cp ./kernel/arch/x86/kvm/kvm-amd.ko $(INSTALL_DIR)
-	/bin/bash -c 'if [ -f /usr/sbin/depmod ]; then /usr/sbin/depmod -a; fi'
+	/bin/bash -c 'if [ -f /usr/sbin/depmod ]; then /usr/sbin/depmod -a $(KERNEL_VERSION_FULLER); fi'

--- a/configure
+++ b/configure
@@ -61,6 +61,7 @@ echo "KERNEL_CONFIG_FILE = /boot/config-$KERNEL_VERSION$KERNEL_FLAVOR" >> config
 echo "KERNEL_SYMVERS_FILE = /usr/src/linux-headers-$KERNEL_VERSION$KERNEL_FLAVOR/Module.symvers" >> config.mk
 echo 'INSTALL_DIR = $(DESTDIR)$(KERNEL_LIB_PATH)/updates/introvirt/' >> config.mk
 echo "PATCH_VERSION = $PATCH_VERSION" >> config.mk
+echo "KERNEL_VERSION_FULLER = $KERNEL_VERSION$KERNEL_FLAVOR" >> config.mk
 
 rm -f debian/*.install debian/*.postinst
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-kvm-introvirt (5.4.0-99.112-0.57.0~focal1) focal; urgency=medium
+kvm-introvirt (5.4.0-109.123-0.57.0~focal1) focal; urgency=medium
 
-  * Initial build for 5.4.0-99.112
+  * Initial build for 5.4.0-109.123
 
  -- Stephen Pape <srpape@gmail.com>  Tue, 31 Aug 2021 12:55:25 -0400

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,8 @@ Source: kvm-introvirt
 Section: devel
 Priority: optional
 Maintainer: Stephen Pape <srpape@gmail.com>
-Build-Depends: linux-modules-5.4.0-99-generic,
-               linux-headers-5.4.0-99-generic,
+Build-Depends: linux-modules-5.4.0-109-generic,
+               linux-headers-5.4.0-109-generic,
                bc,
                devscripts,
                quilt,
@@ -18,12 +18,12 @@ Homepage: https://github.com/IntroVirt/kvm-introvirt/
 Vcs-Browser: https://github.com/IntroVirt/kvm-introvirt/
 Vcs-Git: https://github.com/IntroVirt/kvm-introvirt.git
 
-Package: kvm-introvirt-5.4.0-99-generic
+Package: kvm-introvirt-5.4.0-109-generic
 Section: libs
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends},
-         linux-image-5.4.0-99-generic
+         linux-image-5.4.0-109-generic
 Multi-Arch: same
 Description: virtual machine introspection library
  Virtual machine introspection KVM driver
@@ -33,7 +33,7 @@ Section: libs
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends},
-         kvm-introvirt-5.4.0-99-generic (=${source:Version})
+         kvm-introvirt-5.4.0-109-generic (=${source:Version})
 Multi-Arch: same
 Description: virtual machine introspection library
  Virtual machine introspection KVM driver


### PR DESCRIPTION
Add initial support for CI:
- Verify the kernel module build
- Upload deb package artifacts