### PR TITLE
6.8.0 41 patch fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,11 @@ jobs:
           LSB_CODENAME=${{ matrix.config.codename}} \
           LSB_RELEASE=${{ matrix.config.release}} \
           USE_KERNEL_CONFIG=/usr/src/linux-headers-${{ matrix.config.kernel }}/.config \
-          ./configure
-
+          ./configure || { test $? -eq 2 && ret=2 && exit 0 || exit 1; }
+          if [[ $ret -eq 2 ]]; then
+              echo "Cannot automate this kernel build. The kernel source is not available in apt for this version!"
+              exit 0
+          fi
           make -j$(nproc) package
         shell: bash
       - name: Archive debian packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           KERNEL_VERSION_FULL=${{ matrix.config.kernel }} \
           LSB_CODENAME=${{ matrix.config.codename}} \
           LSB_RELEASE=${{ matrix.config.release}} \
+          USE_KERNEL_CONFIG=/usr/src/linux-headers-${{ matrix.config.kernel }}/.config \
           ./configure
 
           make -j$(nproc) package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           KERNEL_VERSION_FULL=${{ matrix.config.kernel }} \
           LSB_CODENAME=${{ matrix.config.codename}} \
           LSB_RELEASE=${{ matrix.config.release}} \
-          USE_KERNEL_CONFIG=/boot/config-$(uname -r) \
+          USE_KERNEL_CONFIG=/usr/src/linux-headers-${{ matrix.config.kernel }}/.config \
           ./configure
 
           make -j$(nproc) package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           USE_KERNEL_CONFIG=/usr/src/linux-headers-${{ matrix.config.kernel }}/.config \
           ./configure || { test $? -eq 2 && ret=2 && exit 0 || exit 1; }
           if [[ $ret -eq 2 ]]; then
-              echo "Cannot automate this kernel build. The kernel source is not available in apt for this version!"
+              echo "Cannot automate this kernel build. Could not find kernel source in apt or git for this version!"
               exit 0
           fi
           make -j$(nproc) package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,13 @@ jobs:
 
           # Enable source repos to get kernel source
           sudo sed -i '/^#\s*deb-src /s/^# *//' /etc/apt/sources.list
-          sudo sed -Ei 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+          if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then
+              sudo sed -Ei 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+          fi
           sudo apt-get update
         shell: bash
       - name: Validate Kernel Module Build
         run: |
-          cd kvm-introvirt
-
           # Configure the build with the appropriate kernel version
           KERNEL_VERSION_FULL=${{ matrix.config.kernel }} \
           LSB_CODENAME=${{ matrix.config.codename}} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           - { os: ubuntu-22.04, kernel: 6.8.0-40-generic, codename: jammy, release: 22.04 }
           - { os: ubuntu-24.04, kernel: 6.8.0-41-generic, codename: noble, release: 24.04 }
           - { os: ubuntu-24.04, kernel: 6.8.0-90-generic, codename: noble, release: 24.04 }
+          - { os: ubuntu-24.04, kernel: 6.14.0-37-generic, codename: noble, release: 24.04 }
 
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +55,7 @@ jobs:
           sudo apt-get install -y bc devscripts quilt git flex bison \
             libssl-dev libelf-dev debhelper libncurses-dev gawk openssl \
             dkms libudev-dev libpci-dev libiberty-dev autoconf llvm \
+            libdw-dev dwarves libdwarf-dev \
             linux-headers-${{ matrix.config.kernel }} \
             linux-modules-${{ matrix.config.kernel }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,5 +78,5 @@ jobs:
       - name: Archive debian packages
         uses: actions/upload-artifact@v4
         with:
-          name: kvm-introvirt
-          path: kvm-introvirt-*.deb
+          name: kvm-introvirt-${{ matrix.config.kernel }}.${{ matrix.config.release }}
+          path: dist/*.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,38 +1,81 @@
-#
-# Disabling CI for now - need a better way to run CI build tests against supported kernels
-#
-#name: CI Tests
-#
-#on:
-#  push:
-#    paths-ignore: ['**.md']
-#  pull_request:
-#    paths-ignore: ['**.md']
-#
-#jobs:
-#  Kernel_Module:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - uses: actions/checkout@v2
-#        with:
-#          path: kvm-introvirt
-#      - name: Setup
-#        run: |
-#          sudo apt-get update
-#          sudo apt-get install -y bc devscripts quilt git flex bison \
-#            libssl-dev libelf-dev debhelper
-#        shell: bash
-#      - name: Validate Kernel Module Build
-#        run: |
-#          cd kvm-introvirt
-#          ./configure
-#          source ./.build_vars
-#          sudo apt-get install -y linux-headers-${KERNEL_VERSION}${KERNEL_FLAVOR} \
-#            linux-modules-${KERNEL_VERSION}${KERNEL_FLAVOR}
-#          dpkg-buildpackage -us -uc -j
-#        shell: bash
-#      - name: Archive debian packages
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: kvm-introvirt
-#          path: kvm-introvirt-*.deb
+name: CI Tests
+
+on:
+  push:
+    paths-ignore: ['**.md']
+    branches:
+        - main
+  pull_request:
+    paths-ignore: ['**.md']
+    branches:
+      - main
+
+jobs:
+  # Validate code formatting
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+        shell: bash
+      - name: Validate Shell Scripts
+        run: |
+          mapfile -t scripts < <(find . -iname "*.sh" -or -iname "configure")
+          if ! shellcheck "${scripts[@]}"; then
+              echo "You must fix shell script issues before submitting a pull request"
+              echo ""
+              exit 1
+          fi
+          echo "Your shell scripts are looking real good!"
+        shell: bash
+
+  build:
+    runs-on: ${{ matrix.config.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { os: ubuntu-22.04, kernel: 6.5.0-35-generic, codename: jammy, release: 22.04 }
+          - { os: ubuntu-22.04, kernel: 6.8.0-40-generic, codename: jammy, release: 22.04 }
+          - { os: ubuntu-24.04, kernel: 6.8.0-41-generic, codename: noble, release: 24.04 }
+          - { os: ubuntu-24.04, kernel: 6.8.0-90-generic, codename: noble, release: 24.04 }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install build deps
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bc devscripts quilt git flex bison \
+            libssl-dev libelf-dev debhelper libncurses-dev gawk openssl \
+            dkms libudev-dev libpci-dev libiberty-dev autoconf llvm \
+            linux-headers-${{ matrix.config.kernel }} \
+            linux-modules-${{ matrix.config.kernel }}
+
+          # Enable source repos to get kernel source
+          sudo sed -i '/^#\s*deb-src /s/^# *//' /etc/apt/sources.list
+          sudo sed -Ei 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get update
+        shell: bash
+      - name: Validate Kernel Module Build
+        run: |
+          cd kvm-introvirt
+
+          # Configure the build with the appropriate kernel version
+          KERNEL_VERSION_FULL=${{ matrix.config.kernel }} \
+          LSB_CODENAME=${{ matrix.config.codename}} \
+          LSB_RELEASE=${{ matrix.config.release}} \
+          ./configure
+
+          make -j$(nproc) package
+        shell: bash
+      - name: Archive debian packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: kvm-introvirt
+          path: kvm-introvirt-*.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           KERNEL_VERSION_FULL=${{ matrix.config.kernel }} \
           LSB_CODENAME=${{ matrix.config.codename}} \
           LSB_RELEASE=${{ matrix.config.release}} \
-          USE_KERNEL_CONFIG=/usr/src/linux-headers-${{ matrix.config.kernel }}/.config \
+          USE_KERNEL_CONFIG=/boot/config-$(uname -r) \
           ./configure
 
           make -j$(nproc) package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
           sudo apt-get install -y bc devscripts quilt git flex bison \
             libssl-dev libelf-dev debhelper libncurses-dev gawk openssl \
             dkms libudev-dev libpci-dev libiberty-dev autoconf llvm \
+            libdw-dev dwarves libdwarf-dev \
             linux-headers-${{ matrix.config.kernel }} \
             linux-modules-${{ matrix.config.kernel }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  # Build and publish release assets
+  build:
+    runs-on: ${{ matrix.config.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { os: ubuntu-22.04, kernel: 6.5.0-35-generic, codename: jammy, release: 22.04 }
+          - { os: ubuntu-22.04, kernel: 6.8.0-40-generic, codename: jammy, release: 22.04 }
+          - { os: ubuntu-24.04, kernel: 6.8.0-41-generic, codename: noble, release: 24.04 }
+          - { os: ubuntu-24.04, kernel: 6.8.0-90-generic, codename: noble, release: 24.04 }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install build deps
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bc devscripts quilt git flex bison \
+            libssl-dev libelf-dev debhelper libncurses-dev gawk openssl \
+            dkms libudev-dev libpci-dev libiberty-dev autoconf llvm \
+            linux-headers-${{ matrix.config.kernel }} \
+            linux-modules-${{ matrix.config.kernel }}
+
+          # Enable source repos to get kernel source
+          sudo sed -i '/^#\s*deb-src /s/^# *//' /etc/apt/sources.list
+          if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then
+              sudo sed -Ei 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+          fi
+          sudo apt-get update
+        shell: bash
+      - name: Validate Kernel Module Build
+        run: |
+          # Configure the build with the appropriate kernel version
+          KERNEL_VERSION_FULL=${{ matrix.config.kernel }} \
+          LSB_CODENAME=${{ matrix.config.codename}} \
+          LSB_RELEASE=${{ matrix.config.release}} \
+          USE_KERNEL_CONFIG=/usr/src/linux-headers-${{ matrix.config.kernel }}/.config \
+          ./configure || { test $? -eq 2 && ret=2 && exit 0 || exit 1; }
+          if [[ $ret -eq 2 ]]; then
+              echo "Cannot automate this kernel build. Could not find kernel source in apt or git for this version!"
+              exit 0
+          fi
+          make -j$(nproc) package
+        shell: bash
+      - name: Archive debian packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: kvm-introvirt-${{ matrix.config.kernel }}.${{ matrix.config.release }}
+          path: dist/*.deb
+
+  # Create the release
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Download the built debs from the build job
+      - name: Download Release Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: all-debs
+          pattern: kvm-introvirt-*
+
+      # Create and upload the debs to a new release
+      - name: Upload Release Asset
+        id: upload-release-asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ls -lah ./all-debs
+          cd ./all-debs
+          for rel in kvm-introvirt-*; do
+              echo "Zipping ${rel}"
+              zip -r "${rel}.zip" "${rel}"
+          done
+
+          echo "Uploading release assets"
+          gh release create ${{ github.ref_name }} \
+            --title "Release ${{ github.ref_name }}" \
+            --draft \
+            *.zip
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you cannot find a deb package that matches your OS or kernel version, see bel
     sudo apt-get install -y \
         bc devscripts quilt git flex bison libssl-dev libelf-dev debhelper \
         libncurses-dev gawk openssl dkms libudev-dev libpci-dev libiberty-dev \
-        autoconf llvm \
+        libdw-dev dwarves libdwarf-dev autoconf llvm \
         linux-headers-$(uname -r) \
         linux-modules-$(uname -r)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # kvm-introvirt
 
+[![Discord](https://dcbadge.limes.pink/api/server/https://discord.gg/YSdGvAhSmH?style=flat)](https://discord.gg/YSdGvAhSmH)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/IntroVirt/kvm-introvirt?color=brightgreen)](https://github.com/IntroVirt/kvm-introvirt/releases/latest)
+[![CI Tests](https://github.com/IntroVirt/kvm-introvirt/actions/workflows/ci.yml/badge.svg)](https://github.com/IntroVirt/kvm-introvirt/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
 IntroVirt KVM module. Intel CPUs have full support. AMD CPUs are lacking support for breakpoints but syscall tracing should work.
 
 ## Installation Instructions

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you cannot find a deb package that matches your OS or kernel version, see bel
     ```
 
 1. Clone and build the module (assuming the folder exists for your kernel)
+    * You can install an older supported kernel through `apt`, and boot into it if needed.
 
     ```shell
     git clone https://github.com/IntroVirt/kvm-introvirt.git
@@ -113,7 +114,7 @@ quilt refresh
 quilt rename kvm-introvirt-hwe-$(uname -r)
 
 # Generate the header text for the quilt patch
-cat << EOF 
+cat << EOF
 Description: KVM IntroVirt patch for Ubuntu HWE kernel $(uname -r)
  The KVM IntroVirt patch adds introspection support to KVM. This allows
  for inspection of virtual machine memory and manipulation of running processes in-guest.

--- a/configure
+++ b/configure
@@ -37,7 +37,7 @@ if [[ ! -d "./kernel" ]]; then
         echo "Available versions:"
         apt-cache showsrc linux | grep '^Version:'
         popd > /dev/null || exit 1
-        exit 0  # So CI doesn't fail
+        exit 2  # We handle ret code 2 differently so CI doesn't fail
     fi
     mv linux*"$(echo "${_KERNEL_VERSION_FULL}" | cut -d- -f 1)/" kernel
     rm -f linux*.dsc linux*.tar.gz linux*.diff.gz

--- a/configure
+++ b/configure
@@ -42,7 +42,7 @@ fi
 popd > /dev/null || exit 1
 
 # Determine the kernel config we should use
-if [[ -z "${_USE_KERNEL_CONFIG}" -o ! -f "${_USE_KERNEL_CONFIG}" ]]; then
+if [[ -z "${_USE_KERNEL_CONFIG}" || ! -f "${_USE_KERNEL_CONFIG}" ]]; then
     if [[ -f "/boot/config-${_KERNEL_VERSION_FULL}" ]]; then
         echo "Using running kernel config from /boot"
         USE_KERNEL_CONFIG="/boot/config-${_KERNEL_VERSION_FULL}"

--- a/configure
+++ b/configure
@@ -22,7 +22,23 @@ pushd "${PATCH_DIR}" > /dev/null || exit 1
 
 if [[ ! -d "./kernel" ]]; then
     echo "Getting kernel source. This could take a bit..."
-    apt source linux-image-unsigned-"${_KERNEL_VERSION_FULL}"
+
+    # Figure out the name of the package
+    FULL_VER=$(apt-cache policy linux-image-unsigned-"${_KERNEL_VERSION_FULL}" | grep "Candidate:" | awk '{print $2}')
+    if [[ -z "${FULL_VER}" || $? -ne 0 ]]; then
+        echo "Could not find kernel package linux-image-unsigned-${_KERNEL_VERSION_FULL}"
+        popd > /dev/null || exit 1
+        exit 1
+    fi
+
+    if ! apt-get source linux="${FULL_VER}"; then
+        echo "Could not download kernel source for linux-image-unsigned-${_KERNEL_VERSION_FULL}"
+        echo "Possible this version isn't available anymore."
+        echo "Available versions:"
+        apt-cache showsrc linux | grep '^Version:'
+        popd > /dev/null || exit 1
+        exit 0  # So CI doesn't fail
+    fi
     mv linux*"$(echo "${_KERNEL_VERSION_FULL}" | cut -d- -f 1)/" kernel
     rm -f linux*.dsc linux*.tar.gz linux*.diff.gz
     chmod +x kernel/scripts/*.sh

--- a/configure
+++ b/configure
@@ -38,13 +38,32 @@ if [[ ! -d "./kernel" ]]; then
         apt-cache showsrc linux | grep '^Version:'
 
         REPO_URL="git://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/${_LSB_CODENAME}"
-        GIT_TAG="Ubuntu-${FULL_VER}"
 
-        echo "Falling back to Git clone: ${REPO_URL} at tag ${GIT_TAG}"
-        if git clone --depth 1 --branch "${GIT_TAG}" "${REPO_URL}" ./kernel; then
-            echo "Successfully cloned kernel from Git at tag ${GIT_TAG}"
-        else
-            echo "Failed to find tag ${GIT_TAG} at ${REPO_URL}"
+        # Gotta find it somewhere
+        FALLBACK_TAG=$(git ls-remote --tags git://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/noble | grep "${FULL_VER%~*}" | cut -d/ -f3- | head -n1)
+
+        # Create a few tags to try
+        GIT_TAGS=(
+            "Ubuntu-hwe-${FULL_VER}"
+            "Ubuntu-hwe-${FULL_VER%~*}"
+            "Ubuntu-${FULL_VER}"
+            "Ubuntu-${FULL_VER%~*}"
+            "Ubuntu-${_KERNEL_VERSION_FULL}"
+            "Ubuntu-hwe-${_KERNEL_VERSION_FULL}"
+            "${FALLBACK_TAG}"
+        )
+        echo "Falling back to Git clone: ${REPO_URL}"
+        for GIT_TAG in "${GIT_TAGS[@]}"; do
+            echo "Trying to clone tag ${GIT_TAG}..."
+            if git clone --depth 1 --branch "${GIT_TAG}" "${REPO_URL}" ./kernel; then
+                echo "Successfully cloned kernel from Git at tag ${GIT_TAG}"
+                break
+            else
+                echo "Failed to find tag ${GIT_TAG} at ${REPO_URL}"
+            fi
+        done
+        if [[ ! -d "./kernel" ]]; then
+            echo "Failed to download kernel source from Git as well. Cannot continue."
             popd > /dev/null || exit 1
             exit 2
         fi
@@ -92,7 +111,7 @@ truncate -s0 config.mk
     echo "KERNEL_SYMVERS_FILE=/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/Module.symvers"
     echo "PATCH_VERSION=${PATCH_VERSION}"
     echo "INSTALL_DIR=/lib/modules/${_KERNEL_VERSION_FULL}/updates/introvirt/"
-    echo "DEB_NAME=kvm-introvirt-${KERNEL_VERSION_FULL}.${LSB_RELEASE}-${PATCH_VERSION}.deb"
+    echo "DEB_NAME=kvm-introvirt-${KERNEL_VERSION_FULL}.${_LSB_RELEASE}-${PATCH_VERSION}.deb"
     echo "KERNEL_VERSION_FULL=${KERNEL_VERSION_FULL}"
 } >> config.mk
 
@@ -109,7 +128,7 @@ sed -i "s/KERNEL_VERSION_FULL=\"<<<REPLACED_BY_CONFIGURE>>>\"/KERNEL_VERSION_FUL
 # Build the changelog
 truncate -s0 debpkg/DEBIAN/changelog
 cat << EOF > debpkg/DEBIAN/changelog
-kvm-introvirt (${KERNEL_VERSION_FULL}.${LSB_RELEASE}-${PATCH_VERSION}~${LSB_CODENAME}1) ${LSB_CODENAME}; urgency=medium
+kvm-introvirt (${KERNEL_VERSION_FULL}.${_LSB_RELEASE}-${PATCH_VERSION}~${_LSB_CODENAME}1) ${_LSB_CODENAME}; urgency=medium
 
   * kvm-introvirt patch ${PATCH_VERSION} for ${KERNEL_VERSION_FULL}
 

--- a/configure
+++ b/configure
@@ -91,13 +91,13 @@ popd > /dev/null || exit 1
 if [[ -z "${_USE_KERNEL_CONFIG}" || ! -f "${_USE_KERNEL_CONFIG}" ]]; then
     if [[ -f "/boot/config-${_KERNEL_VERSION_FULL}" ]]; then
         echo "Using running kernel config from /boot"
-        USE_KERNEL_CONFIG="/boot/config-${_KERNEL_VERSION_FULL}"
+        _USE_KERNEL_CONFIG="/boot/config-${_KERNEL_VERSION_FULL}"
     elif [[ -f "/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/.config" ]]; then
         echo "Using kernel config from linux-headers"
-        USE_KERNEL_CONFIG="/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/.config"
+        _USE_KERNEL_CONFIG="/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/.config"
     else
         echo "Using kernel config from patch directory"
-        USE_KERNEL_CONFIG="${PATCH_DIR}/kernel/.config"
+        _USE_KERNEL_CONFIG="${PATCH_DIR}/kernel/.config"
     fi
 else
     echo "Using user specified kernel config: ${_USE_KERNEL_CONFIG}"

--- a/configure
+++ b/configure
@@ -10,7 +10,7 @@ PATCH_DIR="ubuntu/${_LSB_CODENAME}/hwe/${_KERNEL_VERSION_FULL}"
 PATCH_VERSION="1.0.0"
 EMAIL="${DEBEMAIL:=laplantes@ainfosec.com}"
 FULLNAME="${DEBFULLNAME:=Sean LaPlante}"
-USE_KERNEL_CONFIG=""
+_USE_KERNEL_CONFIG=${USE_KERNEL_CONFIG:=""}
 
 if [[ ! -d "${PATCH_DIR}" ]]; then
     echo "No patch for ${_KERNEL_VERSION_FULL} in ${_LSB_CODENAME} HWE."
@@ -42,22 +42,26 @@ fi
 popd > /dev/null || exit 1
 
 # Determine the kernel config we should use
-if [[ -f "/boot/config-${_KERNEL_VERSION_FULL}" ]]; then
-    echo "Using running kernel config from /boot"
-    USE_KERNEL_CONFIG="/boot/config-${_KERNEL_VERSION_FULL}"
-elif [[ -f "/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/.config" ]]; then
-    echo "Using kernel config from linux-headers"
-    USE_KERNEL_CONFIG="/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/.config"
+if [[ -z "${_USE_KERNEL_CONFIG}" -o ! -f "${_USE_KERNEL_CONFIG}" ]]; then
+    if [[ -f "/boot/config-${_KERNEL_VERSION_FULL}" ]]; then
+        echo "Using running kernel config from /boot"
+        USE_KERNEL_CONFIG="/boot/config-${_KERNEL_VERSION_FULL}"
+    elif [[ -f "/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/.config" ]]; then
+        echo "Using kernel config from linux-headers"
+        USE_KERNEL_CONFIG="/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/.config"
+    else
+        echo "Using kernel config from patch directory"
+        USE_KERNEL_CONFIG="${PATCH_DIR}/kernel/.config"
+    fi
 else
-    echo "Using kernel config from patch directory"
-    USE_KERNEL_CONFIG="${PATCH_DIR}/kernel/.config"
+    echo "Using user specified kernel config: ${_USE_KERNEL_CONFIG}"
 fi
 
 # Create the config.mk file
 truncate -s0 config.mk
 {
     echo "WORKING_DIR=${PATCH_DIR}"
-    echo "KERNEL_CONFIG_FILE=${USE_KERNEL_CONFIG}"
+    echo "KERNEL_CONFIG_FILE=${_USE_KERNEL_CONFIG}"
     echo "KERNEL_SYMVERS_FILE=/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/Module.symvers"
     echo "PATCH_VERSION=${PATCH_VERSION}"
     echo "INSTALL_DIR=/lib/modules/${_KERNEL_VERSION_FULL}/updates/introvirt/"

--- a/configure
+++ b/configure
@@ -10,19 +10,20 @@ PATCH_DIR="ubuntu/${_LSB_CODENAME}/hwe/${_KERNEL_VERSION_FULL}"
 PATCH_VERSION="1.0.0"
 EMAIL="${DEBEMAIL:=laplantes@ainfosec.com}"
 FULLNAME="${DEBFULLNAME:=Sean LaPlante}"
+USE_KERNEL_CONFIG=""
 
-if [[ ! -d ${PATCH_DIR} ]]; then
+if [[ ! -d "${PATCH_DIR}" ]]; then
     echo "No patch for ${_KERNEL_VERSION_FULL} in ${_LSB_CODENAME} HWE."
     echo "Make the ${PATCH_DIR} directory and copy most recent patch files over to start working on the patch."
     exit 1
 fi
 
-pushd ${PATCH_DIR} > /dev/null
+pushd "${PATCH_DIR}" > /dev/null || exit 1
 
 if [[ ! -d "./kernel" ]]; then
     echo "Getting kernel source. This could take a bit..."
     apt source linux-image-unsigned-"${_KERNEL_VERSION_FULL}"
-    mv linux*$(echo "${_KERNEL_VERSION_FULL}" | cut -d- -f 1)/ kernel
+    mv linux*"$(echo "${_KERNEL_VERSION_FULL}" | cut -d- -f 1)/" kernel
     rm -f linux*.dsc linux*.tar.gz linux*.diff.gz
     chmod +x kernel/scripts/*.sh
 fi
@@ -34,21 +35,35 @@ if quilt unapplied; then
         echo "Then update the patch with \"quilt refresh\" followed by \"quilt pop -a\""
         echo "Make sure to \"quilt add <path>\" for any new files that may need to be patched before"
         echo "making any changes to those files."
-        popd > /dev/null
+        popd > /dev/null || exit 1
         exit 1
     fi
 fi
-popd > /dev/null
+popd > /dev/null || exit 1
+
+# Determine the kernel config we should use
+if [[ -f "/boot/config-${_KERNEL_VERSION_FULL}" ]]; then
+    echo "Using running kernel config from /boot"
+    USE_KERNEL_CONFIG="/boot/config-${_KERNEL_VERSION_FULL}"
+elif [[ -f "/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/.config" ]]; then
+    echo "Using kernel config from linux-headers"
+    USE_KERNEL_CONFIG="/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/.config"
+else
+    echo "Using kernel config from patch directory"
+    USE_KERNEL_CONFIG="${PATCH_DIR}/kernel/.config"
+fi
 
 # Create the config.mk file
 truncate -s0 config.mk
-echo "WORKING_DIR=${PATCH_DIR}" >> config.mk
-echo "KERNEL_CONFIG_FILE=/boot/config-${_KERNEL_VERSION_FULL}" >> config.mk
-echo "KERNEL_SYMVERS_FILE=/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/Module.symvers" >> config.mk
-echo "PATCH_VERSION=${PATCH_VERSION}" >> config.mk
-echo "INSTALL_DIR=/lib/modules/${_KERNEL_VERSION_FULL}/updates/introvirt/" >> config.mk
-echo "DEB_NAME=kvm-introvirt-${KERNEL_VERSION_FULL}.${LSB_RELEASE}-${PATCH_VERSION}.deb" >> config.mk
-echo "KERNEL_VERSION_FULL=${KERNEL_VERSION_FULL}" >> config.mk
+{
+    echo "WORKING_DIR=${PATCH_DIR}"
+    echo "KERNEL_CONFIG_FILE=${USE_KERNEL_CONFIG}"
+    echo "KERNEL_SYMVERS_FILE=/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/Module.symvers"
+    echo "PATCH_VERSION=${PATCH_VERSION}"
+    echo "INSTALL_DIR=/lib/modules/${_KERNEL_VERSION_FULL}/updates/introvirt/"
+    echo "DEB_NAME=kvm-introvirt-${KERNEL_VERSION_FULL}.${LSB_RELEASE}-${PATCH_VERSION}.deb"
+    echo "KERNEL_VERSION_FULL=${KERNEL_VERSION_FULL}"
+} >> config.mk
 
 rm -f debpkg/DEBIAN/postinst debpkg/DEBIAN/postrm debpkg/DEBIAN/preinst
 cp -f debpkg/DEBIAN/postinst.tpl debpkg/DEBIAN/postinst

--- a/configure
+++ b/configure
@@ -3,16 +3,16 @@
 #
 # NOTE: We're assuming Ubuntu and HWE for now
 #
-KERNEL_VERSION_FULL="$(uname -r)"
-LSB_RELEASE=$(lsb_release -sr)
-LSB_CODENAME=$(lsb_release -sc)
-PATCH_DIR="ubuntu/$(lsb_release -sc)/hwe/$(uname -r)"
+_KERNEL_VERSION_FULL=${KERNEL_VERSION_FULL:="$(uname -r)"}
+_LSB_RELEASE=${LSB_RELEASE:="$(lsb_release -sr)"}
+_LSB_CODENAME=${LSB_CODENAME:="$(lsb_release -sc)"}
+PATCH_DIR="ubuntu/${_LSB_CODENAME}/hwe/${_KERNEL_VERSION_FULL}"
 PATCH_VERSION="1.0.0"
 EMAIL="${DEBEMAIL:=laplantes@ainfosec.com}"
 FULLNAME="${DEBFULLNAME:=Sean LaPlante}"
 
 if [[ ! -d ${PATCH_DIR} ]]; then
-    echo "No patch for $(uname -r)".
+    echo "No patch for ${_KERNEL_VERSION_FULL} in ${_LSB_CODENAME} HWE."
     echo "Make the ${PATCH_DIR} directory and copy most recent patch files over to start working on the patch."
     exit 1
 fi
@@ -21,8 +21,8 @@ pushd ${PATCH_DIR} > /dev/null
 
 if [[ ! -d "./kernel" ]]; then
     echo "Getting kernel source. This could take a bit..."
-    apt source linux-image-unsigned-$(uname -r)
-    mv linux*$(uname -r | cut -d- -f 1)/ kernel
+    apt source linux-image-unsigned-"${_KERNEL_VERSION_FULL}"
+    mv linux*$(echo "${_KERNEL_VERSION_FULL}" | cut -d- -f 1)/ kernel
     rm -f linux*.dsc linux*.tar.gz linux*.diff.gz
     chmod +x kernel/scripts/*.sh
 fi
@@ -43,10 +43,10 @@ popd > /dev/null
 # Create the config.mk file
 truncate -s0 config.mk
 echo "WORKING_DIR=${PATCH_DIR}" >> config.mk
-echo "KERNEL_CONFIG_FILE=/boot/config-$(uname -r)" >> config.mk
-echo "KERNEL_SYMVERS_FILE=/usr/src/linux-headers-$(uname -r)/Module.symvers" >> config.mk
+echo "KERNEL_CONFIG_FILE=/boot/config-${_KERNEL_VERSION_FULL}" >> config.mk
+echo "KERNEL_SYMVERS_FILE=/usr/src/linux-headers-${_KERNEL_VERSION_FULL}/Module.symvers" >> config.mk
 echo "PATCH_VERSION=${PATCH_VERSION}" >> config.mk
-echo "INSTALL_DIR=/lib/modules/$(uname -r)/updates/introvirt/" >> config.mk
+echo "INSTALL_DIR=/lib/modules/${_KERNEL_VERSION_FULL}/updates/introvirt/" >> config.mk
 echo "DEB_NAME=kvm-introvirt-${KERNEL_VERSION_FULL}.${LSB_RELEASE}-${PATCH_VERSION}.deb" >> config.mk
 echo "KERNEL_VERSION_FULL=${KERNEL_VERSION_FULL}" >> config.mk
 

--- a/configure
+++ b/configure
@@ -32,15 +32,26 @@ if [[ ! -d "./kernel" ]]; then
     fi
 
     if ! apt-get source linux="${FULL_VER}"; then
-        echo "Could not download kernel source for linux-image-unsigned-${_KERNEL_VERSION_FULL}"
-        echo "Possible this version isn't available anymore."
-        echo "Available versions:"
+        echo "Could not download kernel source for linux-image-unsigned-${_KERNEL_VERSION_FULL} using apt."
+        echo "Possible this version isn't available in apt anymore."
+        echo "Available versions listed are:"
         apt-cache showsrc linux | grep '^Version:'
-        popd > /dev/null || exit 1
-        exit 2  # We handle ret code 2 differently so CI doesn't fail
+
+        REPO_URL="git://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/${_LSB_CODENAME}"
+        GIT_TAG="Ubuntu-${FULL_VER}"
+
+        echo "Falling back to Git clone: ${REPO_URL} at tag ${GIT_TAG}"
+        if git clone --depth 1 --branch "${GIT_TAG}" "${REPO_URL}" ./kernel; then
+            echo "Successfully cloned kernel from Git at tag ${GIT_TAG}"
+        else
+            echo "Failed to find tag ${GIT_TAG} at ${REPO_URL}"
+            popd > /dev/null || exit 1
+            exit 2
+        fi
+    else
+        mv linux*"$(echo "${_KERNEL_VERSION_FULL}" | cut -d- -f 1)/" kernel
+        rm -f linux*.dsc linux*.tar.gz linux*.diff.gz
     fi
-    mv linux*"$(echo "${_KERNEL_VERSION_FULL}" | cut -d- -f 1)/" kernel
-    rm -f linux*.dsc linux*.tar.gz linux*.diff.gz
     chmod +x kernel/scripts/*.sh
 fi
 

--- a/debpkg/DEBIAN/postinst.tpl
+++ b/debpkg/DEBIAN/postinst.tpl
@@ -60,7 +60,13 @@ fi
 if [ $FAILED -ne 0 ]; then
     echo "FAILED TO RELOAD KVM MODULES!!!"
     echo "Please shutdown your VMs and run 'sudo modprobe -r ${WHICH_MOD} kvm && sudo modprobe ${WHICH_MOD}'"
+    exit 1
 else
     echo "Loading ${WHICH_MOD} module"
-    modprobe ${WHICH_MOD}
+    if ! modprobe ${WHICH_MOD}; then
+        echo "Failed to load ${WHICH_MOD} module!"
+        exit 1
+    fi
 fi
+
+exit 0

--- a/debpkg/DEBIAN/postrm.tpl
+++ b/debpkg/DEBIAN/postrm.tpl
@@ -2,9 +2,14 @@
 
 KERNEL_VERSION_FULL="<<<REPLACED_BY_CONFIGURE>>>"
 
-rmmod kvm-intel kvm
+WHICH_MOD="kvm_intel"
+if grep -iq "amd" /proc/cpuinfo; then
+    WHICH_MOD="kvm_amd"
+fi
+
+rmmod ${WHICH_MOD} kvm
 rm -rf "/lib/modules/${KERNEL_VERSION_FULL}/updates/introvirt/"
 depmod -a "${KERNEL_VERSION_FULL}"
-modprobe kvm-intel
+modprobe ${WHICH_MOD}
 
 exit 0

--- a/scripts/auto-patch.sh
+++ b/scripts/auto-patch.sh
@@ -28,7 +28,7 @@ fi
 echo "Creating new patch directory ${NEW_PATCH_DIR} from ${STARTING_PATCH_DIR}..."
 mkdir -p "${NEW_PATCH_DIR}"
 cp -r "${STARTING_PATCH_DIR}/patches" "${NEW_PATCH_DIR}/"
-sed -i "s/${ORIG_KERNEL_VERSION_FULL}/${NEW_KERNEL_VERSION_FULL}/g" "${NEW_PATCH_DIR}/patches/"*
+sed -i "s/${ORIG_KERNEL_VERSION_FULL}/${NEW_KERNEL_VERSION_FULL}/g" "${NEW_PATCH_DIR}/patches/kvm-introvirt-hwe-${ORIG_KERNEL_VERSION_FULL}"
 
 echo "Configuring for new kernel version ${NEW_KERNEL_VERSION_FULL}..."
 KERNEL_VERSION_FULL=${NEW_KERNEL_VERSION_FULL} \

--- a/scripts/auto-patch.sh
+++ b/scripts/auto-patch.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Helper script to auto-patch the kernel from a given starting patch and new kernel version
+# Run from the root of the repo
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <path-to-starting-patch> <new-kernel-version-path>"
+    echo "    Example: $0 ubuntu/noble/hwe/6.8.0-90-generic ubuntu/noble/hwe/6.14.0-37-generic"
+    exit 1
+fi
+
+ORIG_KERNEL_VERSION_FULL=$(basename "$1")
+NEW_KERNEL_VERSION_FULL=$(basename "$2")
+NEW_CODENAME="$(echo "$2" | awk -F'/' '{print $2;}')"
+STARTING_PATCH_DIR="$1"
+NEW_PATCH_DIR="$2"
+
+if [[ ! -d "${STARTING_PATCH_DIR}" ]]; then
+    echo "Starting patch directory ${STARTING_PATCH_DIR} does not exist!"
+    exit 1
+fi
+
+if [[ -d "${NEW_PATCH_DIR}" ]]; then
+    echo "New patch directory ${NEW_PATCH_DIR} already exists!"
+    exit 1
+fi
+
+echo "Creating new patch directory ${NEW_PATCH_DIR} from ${STARTING_PATCH_DIR}..."
+mkdir -p "${NEW_PATCH_DIR}"
+cp -r "${STARTING_PATCH_DIR}/patches" "${NEW_PATCH_DIR}/"
+sed -i "s/${ORIG_KERNEL_VERSION_FULL}/${NEW_KERNEL_VERSION_FULL}/g" "${NEW_PATCH_DIR}/patches/"*
+
+echo "Configuring for new kernel version ${NEW_KERNEL_VERSION_FULL}..."
+KERNEL_VERSION_FULL=${NEW_KERNEL_VERSION_FULL} \
+LSB_CODENAME=${NEW_CODENAME} \
+./configure
+
+ret=$?
+if [[ $ret -ne 0 ]]; then
+    echo "Configuration failed! See output above. Manual patching may be required."
+    exit $ret
+fi
+
+echo "Updating quilt metadata..."
+quilt rename kvm-introvirt-hwe-"${NEW_KERNEL_VERSION_FULL}"
+
+echo "Patch created successfully in ${NEW_PATCH_DIR}"
+echo "Update the quilt header, branch, and create a PR. Instructions in README.md"
+exit 0

--- a/scripts/build-and-sign.sh
+++ b/scripts/build-and-sign.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Helper script to build a kvm-introvirt deb with signed .ko files.
+# Will sign kernel modules with your own MOK key.
+# Run from the root of the repo
+
+set -e
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <path-to-signing-key-dir>"
+    exit 1
+fi
+
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root"
+    exit 1
+fi
+
+SIGNING_KEY_DIR="$1"
+
+./configure
+make -j$(nproc)
+
+echo "Remove BTF section..."
+objcopy --remove-section .BTF ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm.ko
+objcopy --remove-section .BTF ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm-intel.ko
+objcopy --remove-section .BTF ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm-amd.ko
+
+echo "Signing kernel modules..."
+ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/scripts/sign-file \
+    sha256 "${SIGNING_KEY_DIR}/MOK.priv" \
+    "${SIGNING_KEY_DIR}/MOK.der" ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm-intel.ko
+ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/scripts/sign-file \
+    sha256 "${SIGNING_KEY_DIR}/MOK.priv" "${SIGNING_KEY_DIR}/MOK.der" \
+    ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm.ko
+ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/scripts/sign-file \
+    sha256 "${SIGNING_KEY_DIR}/MOK.priv" "${SIGNING_KEY_DIR}/MOK.der" \
+    ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm-amd.ko
+
+make package
+
+echo "kvm-introvirt kernel modules signed and built into ./dist/kvm-introvirt-$(uname -r).$(lsb_release -sr)-X.X.X.deb"

--- a/scripts/build-and-sign.sh
+++ b/scripts/build-and-sign.sh
@@ -19,23 +19,24 @@ fi
 SIGNING_KEY_DIR="$1"
 
 ./configure
-make -j$(nproc)
+make -j"$(nproc)"
 
 echo "Remove BTF section..."
-objcopy --remove-section .BTF ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm.ko
-objcopy --remove-section .BTF ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm-intel.ko
-objcopy --remove-section .BTF ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm-amd.ko
+objcopy --remove-section .BTF "ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm.ko"
+objcopy --remove-section .BTF "ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm-intel.ko"
+objcopy --remove-section .BTF "ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm-amd.ko"
 
 echo "Signing kernel modules..."
-ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/scripts/sign-file \
+"ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/scripts/sign-file" \
     sha256 "${SIGNING_KEY_DIR}/MOK.priv" \
-    "${SIGNING_KEY_DIR}/MOK.der" ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm-intel.ko
-ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/scripts/sign-file \
+    "${SIGNING_KEY_DIR}/MOK.der" \
+    "ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm-intel.ko"
+"ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/scripts/sign-file" \
     sha256 "${SIGNING_KEY_DIR}/MOK.priv" "${SIGNING_KEY_DIR}/MOK.der" \
-    ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm.ko
-ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/scripts/sign-file \
+    "ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm.ko"
+"ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/scripts/sign-file" \
     sha256 "${SIGNING_KEY_DIR}/MOK.priv" "${SIGNING_KEY_DIR}/MOK.der" \
-    ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm-amd.ko
+    "ubuntu/$(lsb_release -sc)/hwe/$(uname -r)/kernel/arch/x86/kvm/kvm-amd.ko"
 
 make package
 

--- a/scripts/debug-kvm-patch.sh
+++ b/scripts/debug-kvm-patch.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Helper to build an insert modified KVM kernel module for debugging
+# Run from the root of the repo
 
 if [[ $# -ne 2 ]]; then
     echo "Usage: $0 <path-to-kernel-source> <path-to-signing-key-dir>"

--- a/scripts/debug-kvm-patch.sh
+++ b/scripts/debug-kvm-patch.sh
@@ -15,7 +15,7 @@ fi
 KERNEL_SRC=$1
 SIGNING_KEY_DIR=$2
 
-pushd "$KERNEL_SRC" || { echo "Failed to change directory to $KERNEL_SRC"; exit 1; }
+pushd "${KERNEL_SRC}" || { echo "Failed to change directory to ${KERNEL_SRC}"; exit 1; }
 
 echo "Building KVM kernel modules"
 make olddefconfig scripts prepare modules_prepare || { echo "Kernel preparation failed"; exit 1; }
@@ -25,8 +25,8 @@ echo "Signing"
 objcopy --remove-section .BTF ./arch/x86/kvm/kvm.ko
 objcopy --remove-section .BTF ./arch/x86/kvm/kvm-intel.ko
 
-./scripts/sign-file sha256 $SIGNING_KEY_DIR/MOK.priv $SIGNING_KEY_DIR/MOK.der ./arch/x86/kvm/kvm-intel.ko
-./scripts/sign-file sha256 $SIGNING_KEY_DIR/MOK.priv $SIGNING_KEY_DIR/MOK.der ./arch/x86/kvm/kvm.ko
+./scripts/sign-file sha256 "${SIGNING_KEY_DIR}/MOK.priv" "${SIGNING_KEY_DIR}/MOK.der" ./arch/x86/kvm/kvm-intel.ko
+./scripts/sign-file sha256 "${SIGNING_KEY_DIR}/MOK.priv" "${SIGNING_KEY_DIR}/MOK.der" ./arch/x86/kvm/kvm.ko
 
 sudo rmmod kvm_intel kvm || echo "Modules not loaded, skipping rmmod"
 sudo insmod ./arch/x86/kvm/kvm.ko || { echo "Failed to insert kvm.ko"; exit 1; }

--- a/scripts/debug-kvm-patch.sh
+++ b/scripts/debug-kvm-patch.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Helper to build an insert modified KVM kernel module for debugging
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <path-to-kernel-source> <path-to-signing-key-dir>"
+    exit 1
+fi
+
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root"
+    exit 1
+fi
+
+KERNEL_SRC=$1
+SIGNING_KEY_DIR=$2
+
+pushd "$KERNEL_SRC" || { echo "Failed to change directory to $KERNEL_SRC"; exit 1; }
+
+echo "Building KVM kernel modules"
+make olddefconfig scripts prepare modules_prepare || { echo "Kernel preparation failed"; exit 1; }
+make M=arch/x86/kvm/ || { echo "KVM module build failed"; exit 1; }
+
+echo "Signing"
+objcopy --remove-section .BTF ./arch/x86/kvm/kvm.ko
+objcopy --remove-section .BTF ./arch/x86/kvm/kvm-intel.ko
+
+./scripts/sign-file sha256 $SIGNING_KEY_DIR/MOK.priv $SIGNING_KEY_DIR/MOK.der ./arch/x86/kvm/kvm-intel.ko
+./scripts/sign-file sha256 $SIGNING_KEY_DIR/MOK.priv $SIGNING_KEY_DIR/MOK.der ./arch/x86/kvm/kvm.ko
+
+sudo rmmod kvm_intel kvm || echo "Modules not loaded, skipping rmmod"
+sudo insmod ./arch/x86/kvm/kvm.ko || { echo "Failed to insert kvm.ko"; exit 1; }
+sudo insmod ./arch/x86/kvm/kvm-intel.ko || { echo "Failed to insert kvm-intel.ko"; exit 1; }
+popd || { echo "Failed to return to previous directory"; exit 1; }
+
+echo "KVM kernel modules inserted successfully"
+
+exit 0

--- a/scripts/dev-patch.sh
+++ b/scripts/dev-patch.sh
@@ -10,6 +10,7 @@ if [[ $# -ne 1 ]]; then
 fi
 
 KERNEL_VERSION="$(basename "$1")"
+CODENAME="$(echo "$1" | awk -F'/' '{print $2;}')"
 PATCH_DIR="$1"
 
 pushd "${PATCH_DIR}" > /dev/null || exit 1
@@ -26,15 +27,26 @@ if [[ ! -d "./kernel" ]]; then
     fi
 
     if ! apt-get source linux="${FULL_VER}"; then
-        echo "Could not download kernel source for linux-image-unsigned-${KERNEL_VERSION}"
-        echo "Possible this version isn't available anymore."
-        echo "Available versions:"
+        echo "Could not download kernel source for linux-image-unsigned-${_KERNEL_VERSION_FULL} using apt."
+        echo "Possible this version isn't available in apt anymore."
+        echo "Available versions listed are:"
         apt-cache showsrc linux | grep '^Version:'
-        popd > /dev/null || exit 1
-        exit 1
+
+        REPO_URL="git://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/${CODENAME}"
+        GIT_TAG="Ubuntu-${FULL_VER}"
+
+        echo "Falling back to Git clone: ${REPO_URL} at tag ${GIT_TAG}"
+        if git clone --depth 1 --branch "${GIT_TAG}" "${REPO_URL}" ./kernel; then
+            echo "Successfully cloned kernel from Git at tag ${GIT_TAG}"
+        else
+            echo "Failed to find tag ${GIT_TAG} at ${REPO_URL}"
+            popd > /dev/null || exit 1
+            exit 2
+        fi
+    else
+        mv linux*"$(echo "${KERNEL_VERSION}" | cut -d- -f 1)/" kernel
+        rm -f linux*.dsc linux*.tar.gz linux*.diff.gz
     fi
-    mv linux*"$(echo "${KERNEL_VERSION}" | cut -d- -f 1)/" kernel
-    rm -f linux*.dsc linux*.tar.gz linux*.diff.gz
     chmod +x kernel/scripts/*.sh
 fi
 

--- a/scripts/dev-patch.sh
+++ b/scripts/dev-patch.sh
@@ -28,12 +28,12 @@ if [[ ! -d "./kernel" ]]; then
     fi
 
     if ! apt-get source linux="${FULL_VER}"; then
-        echo "Could not download kernel source for linux-image-unsigned-${_KERNEL_VERSION_FULL} using apt."
+        echo "Could not download kernel source for linux-image-unsigned-${KERNEL_VERSION} using apt."
         echo "Possible this version isn't available in apt anymore."
         echo "Available versions listed are:"
         apt-cache showsrc linux | grep '^Version:'
 
-        REPO_URL="git://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/${_LSB_CODENAME}"
+        REPO_URL="git://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/${CODENAME}"
 
         # Gotta find it somewhere
         FALLBACK_TAG=$(git ls-remote --tags git://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/noble | grep "${FULL_VER%~*}" | cut -d/ -f3- | head -n1)
@@ -44,8 +44,8 @@ if [[ ! -d "./kernel" ]]; then
             "Ubuntu-hwe-${FULL_VER%~*}"
             "Ubuntu-${FULL_VER}"
             "Ubuntu-${FULL_VER%~*}"
-            "Ubuntu-${_KERNEL_VERSION_FULL}"
-            "Ubuntu-hwe-${_KERNEL_VERSION_FULL}"
+            "Ubuntu-${KERNEL_VERSION}"
+            "Ubuntu-hwe-${KERNEL_VERSION}"
             "${FALLBACK_TAG}"
         )
         echo "Falling back to Git clone: ${REPO_URL}"

--- a/scripts/dev-patch.sh
+++ b/scripts/dev-patch.sh
@@ -2,6 +2,7 @@
 
 # Helper script to download kernel source and apply the quilt patch for development
 # Assumes deb-src entries are in /etc/apt/sources.list or ubuntu.sources
+# Run from the root of the repo
 
 if [[ $# -ne 1 ]]; then
     echo "Usage: $0 <patch/dir>"
@@ -32,14 +33,33 @@ if [[ ! -d "./kernel" ]]; then
         echo "Available versions listed are:"
         apt-cache showsrc linux | grep '^Version:'
 
-        REPO_URL="git://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/${CODENAME}"
-        GIT_TAG="Ubuntu-${FULL_VER}"
+        REPO_URL="git://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/${_LSB_CODENAME}"
 
-        echo "Falling back to Git clone: ${REPO_URL} at tag ${GIT_TAG}"
-        if git clone --depth 1 --branch "${GIT_TAG}" "${REPO_URL}" ./kernel; then
-            echo "Successfully cloned kernel from Git at tag ${GIT_TAG}"
-        else
-            echo "Failed to find tag ${GIT_TAG} at ${REPO_URL}"
+        # Gotta find it somewhere
+        FALLBACK_TAG=$(git ls-remote --tags git://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/noble | grep "${FULL_VER%~*}" | cut -d/ -f3- | head -n1)
+
+        # Create a few tags to try
+        GIT_TAGS=(
+            "Ubuntu-hwe-${FULL_VER}"
+            "Ubuntu-hwe-${FULL_VER%~*}"
+            "Ubuntu-${FULL_VER}"
+            "Ubuntu-${FULL_VER%~*}"
+            "Ubuntu-${_KERNEL_VERSION_FULL}"
+            "Ubuntu-hwe-${_KERNEL_VERSION_FULL}"
+            "${FALLBACK_TAG}"
+        )
+        echo "Falling back to Git clone: ${REPO_URL}"
+        for GIT_TAG in "${GIT_TAGS[@]}"; do
+            echo "Trying to clone tag ${GIT_TAG}..."
+            if git clone --depth 1 --branch "${GIT_TAG}" "${REPO_URL}" ./kernel; then
+                echo "Successfully cloned kernel from Git at tag ${GIT_TAG}"
+                break
+            else
+                echo "Failed to find tag ${GIT_TAG} at ${REPO_URL}"
+            fi
+        done
+        if [[ ! -d "./kernel" ]]; then
+            echo "Failed to download kernel source from Git as well. Cannot continue."
             popd > /dev/null || exit 1
             exit 2
         fi

--- a/scripts/dev-patch.sh
+++ b/scripts/dev-patch.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Helper script to download kernel source and apply the quilt patch for development
+# Assumes deb-src entries are in /etc/apt/sources.list or ubuntu.sources
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <patch/dir>"
+    echo "    Example: $0 ubuntu/noble/hwe/6.8.0-90-generic"
+    exit 1
+fi
+
+KERNEL_VERSION="$(basename "$1")"
+PATCH_DIR="$1"
+
+pushd "${PATCH_DIR}" > /dev/null || exit 1
+
+if [[ ! -d "./kernel" ]]; then
+    echo "Getting kernel source. This could take a bit..."
+
+    # Figure out the name of the package
+    FULL_VER=$(apt-cache policy linux-image-unsigned-"${KERNEL_VERSION}" | grep "Candidate:" | awk '{print $2}')
+    if [[ -z "${FULL_VER}" || $? -ne 0 ]]; then
+        echo "Could not find kernel package linux-image-unsigned-${KERNEL_VERSION}"
+        popd > /dev/null || exit 1
+        exit 1
+    fi
+
+    if ! apt-get source linux="${FULL_VER}"; then
+        echo "Could not download kernel source for linux-image-unsigned-${KERNEL_VERSION}"
+        echo "Possible this version isn't available anymore."
+        echo "Available versions:"
+        apt-cache showsrc linux | grep '^Version:'
+        popd > /dev/null || exit 1
+        exit 1
+    fi
+    mv linux*"$(echo "${KERNEL_VERSION}" | cut -d- -f 1)/" kernel
+    rm -f linux*.dsc linux*.tar.gz linux*.diff.gz
+    chmod +x kernel/scripts/*.sh
+fi
+
+if quilt unapplied; then
+    # Apply patches
+    if ! quilt push -a; then
+        echo "Patch failed to apply. Use \"quilt push -a -f\" and then reconcile the *.rej files"
+        echo "Then update the patch with \"quilt refresh\" followed by \"quilt pop -a\""
+        echo "Make sure to \"quilt add <path>\" for any new files that may need to be patched before"
+        echo "making any changes to those files."
+        popd > /dev/null || exit 1
+        exit 1
+    fi
+fi
+popd > /dev/null || exit 1
+
+exit 0

--- a/scripts/enable-deb-src.sh
+++ b/scripts/enable-deb-src.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Helper script to enable deb-src packages
+
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root"
+    exit 1
+fi
+
+sed -i '/^#\s*deb-src /s/^# *//' /etc/apt/sources.list
+if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then
+    sed -Ei 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+fi
+apt-get update
+
+exit 0

--- a/scripts/enable-deb-src.sh
+++ b/scripts/enable-deb-src.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Helper script to enable deb-src packages
+# Run from the root of the repo
 
 if [[ $EUID -ne 0 ]]; then
     echo "This script must be run as root"

--- a/ubuntu/noble/hwe/6.14.0-37-generic/patches/kvm-introvirt-hwe-6.14.0-37-generic
+++ b/ubuntu/noble/hwe/6.14.0-37-generic/patches/kvm-introvirt-hwe-6.14.0-37-generic
@@ -139,6 +139,181 @@ Index: 6.14.0-37-generic/kernel/arch/x86/kvm/irq.c
  	if (!lapic_in_kernel(v))
  		return v->arch.interrupt.injected;
  
+Index: 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu.c
+===================================================================
+--- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/mmu/mmu.c
++++ 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu.c
+@@ -4677,6 +4677,37 @@ bool kvm_mmu_may_ignore_guest_pat(void)
+ 
+ int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault)
+ {
++	/* If IntroVirt is hooking EPT faults, deliver here */
++	if (fault->guest_initiated && kvm_is_mem_event_enabled(vcpu->kvm))
++	{
++		/* Look up the fault */
++		struct kvm *kvm = vcpu->kvm;
++		struct mem_access_entry *entry;
++		const u64 gfn = fault->gfn;
++		bool found_match = false;
++
++		mutex_lock(&kvm->mem_access_table.mutex);
++
++		/* Search for the entry */
++		hash_for_each_possible(kvm->mem_access_table.table, entry, node, gfn)
++		{
++			/* Found a match, check requested permission */
++			if(entry->gfn == gfn) {
++				/* Match! */
++				found_match = true;
++				break;
++			}
++		}
++		mutex_unlock(&kvm->mem_access_table.mutex);
++
++		/* If we found a match, deliver it */
++		if (found_match) {
++			printk(KERN_DEBUG "IV-mmu: Matched EPT fault mem event for gfn 0x%08llx. Code: %llu\n", gfn, fault->error_code);
++			kvm_deliver_mem_event(vcpu, fault->addr, fault->error_code);
++			return RET_PF_RETRY;
++		}
++	}
++
+ #ifdef CONFIG_X86_64
+ 	if (tdp_mmu_enabled)
+ 		return kvm_tdp_mmu_page_fault(vcpu, fault);
+@@ -4764,6 +4795,71 @@ long kvm_arch_vcpu_pre_fault_memory(stru
+ 	return min(range->size, end - range->gpa);
+ }
+ 
++static int kvm_tdp_set_pte_perms(struct kvm_vcpu *vcpu, u64 gfn, uint8_t perms, uint8_t* original_perms)
++{
++	struct kvm_shadow_walk_iterator iterator;
++	int result = -ESRCH;
++	u64 gpa = gfn << PAGE_SHIFT;
++	u64 spte = 0ull;
++
++	// Turn off any extra bits in the perms
++	perms &= (PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK);
++
++	// Validate the HAP permissions are allowed
++	if (unlikely(!kvm_x86_ops.hap_permissions_allowed(perms)))
++		return -EINVAL;
++
++	if (!VALID_PAGE(vcpu->arch.mmu->root.hpa))
++	{
++		result = kvm_mmu_load(vcpu);
++		if (unlikely(result))
++			return result;
++	}
++
++retry:
++	walk_shadow_page_lockless_begin(vcpu);
++
++	/* Find the page in the shadow tables */
++	for_each_shadow_entry_lockless(vcpu, gpa, iterator, spte)
++		if (!is_shadow_present_pte(spte) ||
++			iterator.level < PG_LEVEL_4K)
++				{
++					/* The page is not present, so page it in for the guest process */
++					struct mm_struct* mm;
++					int r;
++
++					walk_shadow_page_lockless_end(vcpu);
++
++					/* Dirty hack */
++					/* hva_to_pfn() is hard-coded to current->mm */
++					mm = current->mm;
++					current->mm = vcpu->kvm->mm;
++					r = __kvm_mmu_do_page_fault(vcpu, gpa, 0, false, NULL, NULL, false);
++					current->mm = mm;
++					if (r)
++						return r;
++					goto retry;
++				}
++
++	// Try a few times to update the pte
++	result = -EBUSY;
++	do {
++		u64 new_spte = (spte & ~(PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK)) | perms;
++
++		if (original_perms != NULL)
++			*original_perms = (spte & (PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK));
++
++		if (cmpxchg64(iterator.sptep, spte, new_spte) == spte)
++		{
++			result = 0;
++			break;
++		}
++	} while(true);
++
++	walk_shadow_page_lockless_end(vcpu);
++	return result;
++}
++
+ static void nonpaging_init_context(struct kvm_mmu *context)
+ {
+ 	context->page_fault = nonpaging_page_fault;
+@@ -5464,6 +5560,7 @@ static void init_kvm_tdp_mmu(struct kvm_
+ 	context->cpu_role.as_u64 = cpu_role.as_u64;
+ 	context->root_role.word = root_role.word;
+ 	context->page_fault = kvm_tdp_page_fault;
++	context->set_pte_perms = kvm_tdp_set_pte_perms;
+ 	context->sync_spte = NULL;
+ 	context->get_guest_pgd = get_guest_cr3;
+ 	context->get_pdptr = kvm_pdptr_read;
+Index: 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
+===================================================================
+--- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/mmu/mmu_internal.h
++++ 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
+@@ -294,6 +294,11 @@ struct kvm_page_fault {
+ 	 * is changing its own translation in the guest page tables.
+ 	 */
+ 	bool write_fault_to_shadow_pgtable;
++
++	/*
++	 * IntroVirt Patch
++	 */
++	bool guest_initiated;
+ };
+ 
+ int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault);
+@@ -343,9 +348,9 @@ static inline void kvm_mmu_prepare_memor
+ 				      fault->is_private);
+ }
+ 
+-static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
++static inline int __kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
+ 					u64 err, bool prefetch,
+-					int *emulation_type, u8 *level)
++					int *emulation_type, u8 *level, bool guest_initiated)
+ {
+ 	struct kvm_page_fault fault = {
+ 		.addr = cr2_or_gpa,
+@@ -366,6 +371,11 @@ static inline int kvm_mmu_do_page_fault(
+ 		.is_private = err & PFERR_PRIVATE_ACCESS,
+ 
+ 		.pfn = KVM_PFN_ERR_FAULT,
++
++		/*
++		 * IntroVirt Patch
++		 */
++		.guest_initiated = guest_initiated,
+ 	};
+ 	int r;
+ 
+@@ -407,6 +417,12 @@ static inline int kvm_mmu_do_page_fault(
+ 	return r;
+ }
+ 
++static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
++					u32 err, bool prefetch, int *emulation_type, u8 *level)
++{
++	return __kvm_mmu_do_page_fault(vcpu, cr2_or_gpa, err, prefetch, emulation_type, level, 1);
++}
++
+ int kvm_mmu_max_mapping_level(struct kvm *kvm,
+ 			      const struct kvm_memory_slot *slot, gfn_t gfn);
+ void kvm_mmu_hugepage_adjust(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault);
 Index: 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/capabilities.h
 ===================================================================
 --- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/vmx/capabilities.h
@@ -163,6 +338,24 @@ Index: 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/capabilities.h
  static inline bool cpu_need_tpr_shadow(struct kvm_vcpu *vcpu)
  {
  	return cpu_has_vmx_tpr_shadow() && lapic_in_kernel(vcpu);
+Index: 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/main.c
+===================================================================
+--- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/vmx/main.c
++++ 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/main.c
+@@ -159,6 +159,13 @@ struct kvm_x86_ops vt_x86_ops __initdata
+ 	.vcpu_deliver_sipi_vector = kvm_vcpu_deliver_sipi_vector,
+ 
+ 	.get_untagged_addr = vmx_get_untagged_addr,
++
++	/* IntroVirt patch */
++	.update_syscall_intercept = vmx_update_exception_bitmap,
++	.set_cr_monitor = vmx_set_cr_monitor,
++	.set_monitor_trap_flag = vmx_set_monitor_trap_flag,
++	.set_invlpg_monitor = vmx_set_invlpg_monitor,
++	.hap_permissions_allowed = vmx_hap_permissions_allowed,
+ };
+ 
+ struct kvm_x86_init_ops vt_init_ops __initdata = {
 Index: 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/vmx.c
 ===================================================================
 --- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/vmx/vmx.c
@@ -413,6 +606,23 @@ Index: 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/vmx.c
  static unsigned int vmx_handle_intel_pt_intr(void)
  {
  	struct kvm_vcpu *vcpu = kvm_get_running_vcpu();
+Index: 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/vmx.h
+===================================================================
+--- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/vmx/vmx.h
++++ 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/vmx.h
+@@ -426,6 +426,12 @@ u64 vmx_get_l2_tsc_multiplier(struct kvm
+ 
+ gva_t vmx_get_untagged_addr(struct kvm_vcpu *vcpu, gva_t gva, unsigned int flags);
+ 
++/* IntroVirt Patch */
++int vmx_set_cr_monitor(struct kvm_vcpu *vcpu, int cr, int mode);
++int vmx_set_monitor_trap_flag(struct kvm_vcpu *vcpu, bool enabled);
++int vmx_set_invlpg_monitor(struct kvm_vcpu *vcpu, bool enabled);
++bool vmx_hap_permissions_allowed(uint16_t perms);
++
+ static inline void vmx_set_intercept_for_msr(struct kvm_vcpu *vcpu, u32 msr,
+ 					     int type, bool value)
+ {
 Index: 6.14.0-37-generic/kernel/arch/x86/kvm/x86.c
 ===================================================================
 --- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/x86.c
@@ -1900,178 +2110,3 @@ Index: 6.14.0-37-generic/kernel/virt/kvm/kvm_main.c
  	default:
  		return kvm_arch_dev_ioctl(filp, ioctl, arg);
  	}
-Index: 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu.c
-===================================================================
---- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/mmu/mmu.c
-+++ 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu.c
-@@ -4677,6 +4677,37 @@ bool kvm_mmu_may_ignore_guest_pat(void)
- 
- int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault)
- {
-+	/* If IntroVirt is hooking EPT faults, deliver here */
-+	if (fault->guest_initiated && kvm_is_mem_event_enabled(vcpu->kvm))
-+	{
-+		/* Look up the fault */
-+		struct kvm *kvm = vcpu->kvm;
-+		struct mem_access_entry *entry;
-+		const u64 gfn = fault->gfn;
-+		bool found_match = false;
-+
-+		mutex_lock(&kvm->mem_access_table.mutex);
-+
-+		/* Search for the entry */
-+		hash_for_each_possible(kvm->mem_access_table.table, entry, node, gfn)
-+		{
-+			/* Found a match, check requested permission */
-+			if(entry->gfn == gfn) {
-+				/* Match! */
-+				found_match = true;
-+				break;
-+			}
-+		}
-+		mutex_unlock(&kvm->mem_access_table.mutex);
-+
-+		/* If we found a match, deliver it */
-+		if (found_match) {
-+			printk(KERN_DEBUG "IV-mmu: Matched EPT fault mem event for gfn 0x%08llx. Code: %llu\n", gfn, fault->error_code);
-+			kvm_deliver_mem_event(vcpu, fault->addr, fault->error_code);
-+			return RET_PF_RETRY;
-+		}
-+	}
-+
- #ifdef CONFIG_X86_64
- 	if (tdp_mmu_enabled)
- 		return kvm_tdp_mmu_page_fault(vcpu, fault);
-@@ -4764,6 +4795,71 @@ long kvm_arch_vcpu_pre_fault_memory(stru
- 	return min(range->size, end - range->gpa);
- }
- 
-+static int kvm_tdp_set_pte_perms(struct kvm_vcpu *vcpu, u64 gfn, uint8_t perms, uint8_t* original_perms)
-+{
-+	struct kvm_shadow_walk_iterator iterator;
-+	int result = -ESRCH;
-+	u64 gpa = gfn << PAGE_SHIFT;
-+	u64 spte = 0ull;
-+
-+	// Turn off any extra bits in the perms
-+	perms &= (PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK);
-+
-+	// Validate the HAP permissions are allowed
-+	if (unlikely(!kvm_x86_ops.hap_permissions_allowed(perms)))
-+		return -EINVAL;
-+
-+	if (!VALID_PAGE(vcpu->arch.mmu->root.hpa))
-+	{
-+		result = kvm_mmu_load(vcpu);
-+		if (unlikely(result))
-+			return result;
-+	}
-+
-+retry:
-+	walk_shadow_page_lockless_begin(vcpu);
-+
-+	/* Find the page in the shadow tables */
-+	for_each_shadow_entry_lockless(vcpu, gpa, iterator, spte)
-+		if (!is_shadow_present_pte(spte) ||
-+			iterator.level < PG_LEVEL_4K)
-+				{
-+					/* The page is not present, so page it in for the guest process */
-+					struct mm_struct* mm;
-+					int r;
-+
-+					walk_shadow_page_lockless_end(vcpu);
-+
-+					/* Dirty hack */
-+					/* hva_to_pfn() is hard-coded to current->mm */
-+					mm = current->mm;
-+					current->mm = vcpu->kvm->mm;
-+					r = __kvm_mmu_do_page_fault(vcpu, gpa, 0, false, NULL, NULL, false);
-+					current->mm = mm;
-+					if (r)
-+						return r;
-+					goto retry;
-+				}
-+
-+	// Try a few times to update the pte
-+	result = -EBUSY;
-+	do {
-+		u64 new_spte = (spte & ~(PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK)) | perms;
-+
-+		if (original_perms != NULL)
-+			*original_perms = (spte & (PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK));
-+
-+		if (cmpxchg64(iterator.sptep, spte, new_spte) == spte)
-+		{
-+			result = 0;
-+			break;
-+		}
-+	} while(true);
-+
-+	walk_shadow_page_lockless_end(vcpu);
-+	return result;
-+}
-+
- static void nonpaging_init_context(struct kvm_mmu *context)
- {
- 	context->page_fault = nonpaging_page_fault;
-@@ -5464,6 +5560,7 @@ static void init_kvm_tdp_mmu(struct kvm_
- 	context->cpu_role.as_u64 = cpu_role.as_u64;
- 	context->root_role.word = root_role.word;
- 	context->page_fault = kvm_tdp_page_fault;
-+	context->set_pte_perms = kvm_tdp_set_pte_perms;
- 	context->sync_spte = NULL;
- 	context->get_guest_pgd = get_guest_cr3;
- 	context->get_pdptr = kvm_pdptr_read;
-Index: 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
-===================================================================
---- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/mmu/mmu_internal.h
-+++ 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
-@@ -294,6 +294,11 @@ struct kvm_page_fault {
- 	 * is changing its own translation in the guest page tables.
- 	 */
- 	bool write_fault_to_shadow_pgtable;
-+
-+	/*
-+	 * IntroVirt Patch
-+	 */
-+	bool guest_initiated;
- };
- 
- int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault);
-@@ -343,9 +348,9 @@ static inline void kvm_mmu_prepare_memor
- 				      fault->is_private);
- }
- 
--static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
-+static inline int __kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
- 					u64 err, bool prefetch,
--					int *emulation_type, u8 *level)
-+					int *emulation_type, u8 *level, bool guest_initiated)
- {
- 	struct kvm_page_fault fault = {
- 		.addr = cr2_or_gpa,
-@@ -366,6 +371,11 @@ static inline int kvm_mmu_do_page_fault(
- 		.is_private = err & PFERR_PRIVATE_ACCESS,
- 
- 		.pfn = KVM_PFN_ERR_FAULT,
-+
-+		/*
-+		 * IntroVirt Patch
-+		 */
-+		.guest_initiated = guest_initiated,
- 	};
- 	int r;
- 
-@@ -407,6 +417,12 @@ static inline int kvm_mmu_do_page_fault(
- 	return r;
- }
- 
-+static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
-+					u32 err, bool prefetch, int *emulation_type, u8 *level)
-+{
-+	return __kvm_mmu_do_page_fault(vcpu, cr2_or_gpa, err, prefetch, emulation_type, level, 1);
-+}
-+
- int kvm_mmu_max_mapping_level(struct kvm *kvm,
- 			      const struct kvm_memory_slot *slot, gfn_t gfn);
- void kvm_mmu_hugepage_adjust(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault);

--- a/ubuntu/noble/hwe/6.14.0-37-generic/patches/kvm-introvirt-hwe-6.14.0-37-generic
+++ b/ubuntu/noble/hwe/6.14.0-37-generic/patches/kvm-introvirt-hwe-6.14.0-37-generic
@@ -38,7 +38,7 @@ Index: 6.14.0-37-generic/kernel/arch/x86/kvm/emulate.c
 ===================================================================
 --- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/emulate.c
 +++ 6.14.0-37-generic/kernel/arch/x86/kvm/emulate.c
-@@ -2423,6 +2423,69 @@ static int em_syscall(struct x86_emulate
+@@ -2423,6 +2423,77 @@ static int em_syscall(struct x86_emulate
  	return X86EMUL_CONTINUE;
  }
  
@@ -54,7 +54,15 @@ Index: 6.14.0-37-generic/kernel/arch/x86/kvm/emulate.c
 +	if(ctxt->mode == X86EMUL_MODE_REAL || ctxt->mode == X86EMUL_MODE_VM86)
 +		return emulate_ud(ctxt);
 +
-+	if(!(em_syscall_is_enabled(ctxt)))
++	/*
++	 * Intel compatible CPUs only support SYSCALL in 64-bit mode, whereas
++	 * AMD allows SYSCALL in any flavor of protected mode.  Note, it's
++	 * infeasible to emulate Intel behavior when running on AMD hardware,
++	 * as SYSCALL won't fault in the "wrong" mode, i.e. there is no #UD
++	 * for KVM to trap-and-emulate, unlike emulating AMD on Intel.
++	 */
++	if (ctxt->mode != X86EMUL_MODE_PROT64 &&
++	    ctxt->ops->guest_cpuid_is_intel_compatible(ctxt))
 +		return emulate_ud(ctxt);
 +
 +	if(ctxt->ops->cpl(ctxt) != 0) {
@@ -108,7 +116,7 @@ Index: 6.14.0-37-generic/kernel/arch/x86/kvm/emulate.c
  static int em_sysenter(struct x86_emulate_ctxt *ctxt)
  {
  	const struct x86_emulate_ops *ops = ctxt->ops;
-@@ -4369,7 +4432,7 @@ static const struct opcode twobyte_table
+@@ -4369,7 +4440,7 @@ static const struct opcode twobyte_table
  	/* 0x00 - 0x0F */
  	G(0, group6), GD(0, &group7), N, N,
  	N, I(ImplicitOps | EmulateOnUD | IsBranch, em_syscall),
@@ -306,7 +314,7 @@ Index: 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/vmx.c
  	return (sign_extend64(gva, lam_bit) & ~BIT_ULL(63)) | (gva & BIT_ULL(63));
  }
  
-+static int vmx_set_cr_monitor(struct kvm_vcpu *vcpu, int cr, int mode)
++int vmx_set_cr_monitor(struct kvm_vcpu *vcpu, int cr, int mode)
 +{
 +	struct vcpu_vmx *vmx = to_vmx(vcpu);
 +
@@ -358,7 +366,7 @@ Index: 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/vmx.c
 +	return 0;
 +}
 +
-+static int vmx_set_monitor_trap_flag(struct kvm_vcpu *vcpu, bool enabled) {
++int vmx_set_monitor_trap_flag(struct kvm_vcpu *vcpu, bool enabled) {
 +	struct vcpu_vmx *vmx = to_vmx(vcpu);
 +
 +	if (!cpu_has_monitor_trap_flag())
@@ -373,7 +381,7 @@ Index: 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/vmx.c
 +	return 0;
 +}
 +
-+static int vmx_set_invlpg_monitor(struct kvm_vcpu *vcpu, bool enabled) {
++int vmx_set_invlpg_monitor(struct kvm_vcpu *vcpu, bool enabled) {
 +	struct vcpu_vmx *vmx = to_vmx(vcpu);
 +
 +	/* Without ept, we always need it set */
@@ -387,7 +395,7 @@ Index: 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/vmx.c
 +	return 0;
 +}
 +
-+static bool vmx_hap_permissions_allowed(uint16_t perms) {
++bool vmx_hap_permissions_allowed(uint16_t perms) {
 +	if ((perms & PT_PRESENT_MASK) == 0)
 +	{
 +		if ((perms & PT_WRITABLE_MASK))
@@ -1896,10 +1904,10 @@ Index: 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu.c
 ===================================================================
 --- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/mmu/mmu.c
 +++ 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu.c
-@@ -4626,6 +4626,37 @@ int kvm_handle_page_fault(struct kvm_vcp
- }
- EXPORT_SYMBOL_GPL(kvm_handle_page_fault);
+@@ -4677,6 +4677,37 @@ bool kvm_mmu_may_ignore_guest_pat(void)
  
+ int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault)
+ {
 +	/* If IntroVirt is hooking EPT faults, deliver here */
 +	if (fault->guest_initiated && kvm_is_mem_event_enabled(vcpu->kvm))
 +	{
@@ -1925,15 +1933,15 @@ Index: 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu.c
 +
 +		/* If we found a match, deliver it */
 +		if (found_match) {
-+			printk(KERN_DEBUG "IV-mmu: Matched EPT fault mem event for gfn 0x%08llx. Code: %d\n", gfn, fault->error_code);
++			printk(KERN_DEBUG "IV-mmu: Matched EPT fault mem event for gfn 0x%08llx. Code: %llu\n", gfn, fault->error_code);
 +			kvm_deliver_mem_event(vcpu, fault->addr, fault->error_code);
 +			return RET_PF_RETRY;
 +		}
 +	}
 +
  #ifdef CONFIG_X86_64
- static int kvm_tdp_mmu_page_fault(struct kvm_vcpu *vcpu,
- 				  struct kvm_page_fault *fault)
+ 	if (tdp_mmu_enabled)
+ 		return kvm_tdp_mmu_page_fault(vcpu, fault);
 @@ -4764,6 +4795,71 @@ long kvm_arch_vcpu_pre_fault_memory(stru
  	return min(range->size, end - range->gpa);
  }
@@ -1977,7 +1985,7 @@ Index: 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu.c
 +					/* hva_to_pfn() is hard-coded to current->mm */
 +					mm = current->mm;
 +					current->mm = vcpu->kvm->mm;
-+					r = __kvm_mmu_do_page_fault(vcpu, gpa, 0, false, NULL, false);
++					r = __kvm_mmu_do_page_fault(vcpu, gpa, 0, false, NULL, NULL, false);
 +					current->mm = mm;
 +					if (r)
 +						return r;

--- a/ubuntu/noble/hwe/6.14.0-37-generic/patches/kvm-introvirt-hwe-6.14.0-37-generic
+++ b/ubuntu/noble/hwe/6.14.0-37-generic/patches/kvm-introvirt-hwe-6.14.0-37-generic
@@ -5,25 +5,25 @@ Description: KVM IntroVirt patch for Ubuntu HWE kernel 6.8.0-90-generic
 Author: AIS Inc., introvirt@ainfosec.com
 Origin: upstream, https://github.com/IntroVirt/kvm-introvirt
 Bug: https://github.com/IntroVirt/kvm-introvirt/issues
-Last-Update: 2026-01-28
+Last-Update: 2026-01-29
 ---
 This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
-Index: 6.8.0-90-generic/kernel/arch/x86/include/asm/kvm_host.h
+Index: 6.14.0-37-generic/kernel/arch/x86/include/asm/kvm_host.h
 ===================================================================
---- 6.8.0-90-generic.orig/kernel/arch/x86/include/asm/kvm_host.h
-+++ 6.8.0-90-generic/kernel/arch/x86/include/asm/kvm_host.h
-@@ -454,6 +454,7 @@ struct kvm_mmu {
+--- 6.14.0-37-generic.orig/kernel/arch/x86/include/asm/kvm_host.h
++++ 6.14.0-37-generic/kernel/arch/x86/include/asm/kvm_host.h
+@@ -458,6 +458,7 @@ struct kvm_mmu {
  			    struct x86_exception *exception);
  	int (*sync_spte)(struct kvm_vcpu *vcpu,
  			 struct kvm_mmu_page *sp, int i);
 +	int (*set_pte_perms)(struct kvm_vcpu *vcpu, u64 gpa, uint8_t perms, uint8_t* original_perms);
  	struct kvm_mmu_root_info root;
+ 	hpa_t mirror_root_hpa;
  	union kvm_cpu_role cpu_role;
- 	union kvm_mmu_page_role root_role;
-@@ -1794,6 +1795,13 @@ struct kvm_x86_ops {
- 	unsigned long (*vcpu_get_apicv_inhibit_reasons)(struct kvm_vcpu *vcpu);
- 
- 	gva_t (*get_untagged_addr)(struct kvm_vcpu *vcpu, gva_t gva, unsigned int flags);
+@@ -1878,6 +1879,13 @@ struct kvm_x86_ops {
+ 	int (*gmem_prepare)(struct kvm *kvm, kvm_pfn_t pfn, gfn_t gfn, int max_order);
+ 	void (*gmem_invalidate)(kvm_pfn_t start, kvm_pfn_t end);
+ 	int (*private_max_mapping_level)(struct kvm *kvm, kvm_pfn_t pfn);
 +
 +	/* IntroVirt patch */
 +	int (*set_cr_monitor)(struct kvm_vcpu *vcpu, int cr, int mode);
@@ -34,11 +34,11 @@ Index: 6.8.0-90-generic/kernel/arch/x86/include/asm/kvm_host.h
  };
  
  struct kvm_x86_nested_ops {
-Index: 6.8.0-90-generic/kernel/arch/x86/kvm/emulate.c
+Index: 6.14.0-37-generic/kernel/arch/x86/kvm/emulate.c
 ===================================================================
---- 6.8.0-90-generic.orig/kernel/arch/x86/kvm/emulate.c
-+++ 6.8.0-90-generic/kernel/arch/x86/kvm/emulate.c
-@@ -2455,6 +2455,69 @@ static int em_syscall(struct x86_emulate
+--- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/emulate.c
++++ 6.14.0-37-generic/kernel/arch/x86/kvm/emulate.c
+@@ -2423,6 +2423,69 @@ static int em_syscall(struct x86_emulate
  	return X86EMUL_CONTINUE;
  }
  
@@ -108,7 +108,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/emulate.c
  static int em_sysenter(struct x86_emulate_ctxt *ctxt)
  {
  	const struct x86_emulate_ops *ops = ctxt->ops;
-@@ -4402,7 +4465,7 @@ static const struct opcode twobyte_table
+@@ -4369,7 +4432,7 @@ static const struct opcode twobyte_table
  	/* 0x00 - 0x0F */
  	G(0, group6), GD(0, &group7), N, N,
  	N, I(ImplicitOps | EmulateOnUD | IsBranch, em_syscall),
@@ -117,10 +117,10 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/emulate.c
  	DI(ImplicitOps | Priv, invd), DI(ImplicitOps | Priv, wbinvd), N, N,
  	N, D(ImplicitOps | ModRM | SrcMem | NoAccess), N, N,
  	/* 0x10 - 0x1F */
-Index: 6.8.0-90-generic/kernel/arch/x86/kvm/irq.c
+Index: 6.14.0-37-generic/kernel/arch/x86/kvm/irq.c
 ===================================================================
---- 6.8.0-90-generic.orig/kernel/arch/x86/kvm/irq.c
-+++ 6.8.0-90-generic/kernel/arch/x86/kvm/irq.c
+--- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/irq.c
++++ 6.14.0-37-generic/kernel/arch/x86/kvm/irq.c
 @@ -58,6 +58,9 @@ int kvm_cpu_has_extint(struct kvm_vcpu *
  	 * pending interrupt or should re-inject an injected
  	 * interrupt.
@@ -131,11 +131,11 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/irq.c
  	if (!lapic_in_kernel(v))
  		return v->arch.interrupt.injected;
  
-Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/capabilities.h
+Index: 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/capabilities.h
 ===================================================================
---- 6.8.0-90-generic.orig/kernel/arch/x86/kvm/vmx/capabilities.h
-+++ 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/capabilities.h
-@@ -71,6 +71,7 @@ extern struct vmcs_config vmcs_config __
+--- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/vmx/capabilities.h
++++ 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/capabilities.h
+@@ -69,6 +69,7 @@ extern struct vmcs_config vmcs_config __
  struct vmx_capability {
  	u32 ept;
  	u32 vpid;
@@ -143,7 +143,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/capabilities.h
  };
  extern struct vmx_capability vmx_capability __ro_after_init;
  
-@@ -116,6 +117,11 @@ static inline bool cpu_has_vmx_tpr_shado
+@@ -114,6 +115,11 @@ static inline bool cpu_has_vmx_tpr_shado
  	return vmcs_config.cpu_based_exec_ctrl & CPU_BASED_TPR_SHADOW;
  }
  
@@ -155,11 +155,11 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/capabilities.h
  static inline bool cpu_need_tpr_shadow(struct kvm_vcpu *vcpu)
  {
  	return cpu_has_vmx_tpr_shadow() && lapic_in_kernel(vcpu);
-Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/vmx.c
+Index: 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/vmx.c
 ===================================================================
---- 6.8.0-90-generic.orig/kernel/arch/x86/kvm/vmx/vmx.c
-+++ 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/vmx.c
-@@ -874,7 +874,7 @@ void vmx_update_exception_bitmap(struct
+--- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/vmx/vmx.c
++++ 6.14.0-37-generic/kernel/arch/x86/kvm/vmx/vmx.c
+@@ -885,7 +885,7 @@ void vmx_update_exception_bitmap(struct
  	 * We intercept those #GP and allow access to them anyway
  	 * as VMware does.
  	 */
@@ -168,7 +168,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/vmx.c
  		eb |= (1u << GP_VECTOR);
  	if ((vcpu->guest_debug &
  	     (KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP)) ==
-@@ -1107,6 +1107,11 @@ static bool update_transition_efer(struc
+@@ -1118,6 +1118,11 @@ static bool update_transition_efer(struc
  		ignore_bits &= ~(u64)EFER_SCE;
  #endif
  
@@ -180,7 +180,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/vmx.c
  	/*
  	 * On EPT, we can't emulate NX, so we must switch EFER atomically.
  	 * On CPUs that support "load IA32_EFER", always switch EFER
-@@ -2010,7 +2015,8 @@ static int vmx_get_msr(struct kvm_vcpu *
+@@ -2057,7 +2062,8 @@ int vmx_get_msr(struct kvm_vcpu *vcpu, s
  		msr_info->data = to_vmx(vcpu)->spec_ctrl;
  		break;
  	case MSR_IA32_SYSENTER_CS:
@@ -190,7 +190,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/vmx.c
  		break;
  	case MSR_IA32_SYSENTER_EIP:
  		msr_info->data = vmcs_readl(GUEST_SYSENTER_EIP);
-@@ -2615,6 +2621,13 @@ static int setup_vmcs_config(struct vmcs
+@@ -2643,6 +2649,13 @@ static int setup_vmcs_config(struct vmcs
  				SECONDARY_EXEC_VIRTUALIZE_X2APIC_MODE |
  				SECONDARY_EXEC_VIRTUAL_INTR_DELIVERY);
  
@@ -204,7 +204,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/vmx.c
  	rdmsr_safe(MSR_IA32_VMX_EPT_VPID_CAP,
  		&vmx_cap->ept, &vmx_cap->vpid);
  
-@@ -5209,7 +5222,7 @@ static int handle_exception_nmi(struct k
+@@ -5266,7 +5279,7 @@ static int handle_exception_nmi(struct k
  		error_code = vmcs_read32(VM_EXIT_INTR_ERROR_CODE);
  
  	if (!vmx->rmode.vm86_active && is_gp_fault(intr_info)) {
@@ -213,7 +213,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/vmx.c
  
  		/*
  		 * VMware backdoor emulation on #GP interception only handles
-@@ -5311,6 +5324,24 @@ static int handle_exception_nmi(struct k
+@@ -5368,6 +5381,24 @@ static int handle_exception_nmi(struct k
  		kvm_run->exit_reason = KVM_EXIT_DEBUG;
  		kvm_run->debug.arch.pc = kvm_get_linear_rip(vcpu);
  		kvm_run->debug.arch.exception = ex_no;
@@ -238,7 +238,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/vmx.c
  		break;
  	case AC_VECTOR:
  		if (vmx_guest_inject_ac(vcpu)) {
-@@ -5453,19 +5484,25 @@ static int handle_cr(struct kvm_vcpu *vc
+@@ -5509,19 +5540,25 @@ static int handle_cr(struct kvm_vcpu *vc
  		trace_kvm_cr_write(cr, val);
  		switch (cr) {
  		case 0:
@@ -266,7 +266,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/vmx.c
  				err = kvm_set_cr8(vcpu, cr8);
  				ret = kvm_complete_insn_gp(vcpu, err);
  				if (lapic_in_kernel(vcpu))
-@@ -5493,11 +5530,13 @@ static int handle_cr(struct kvm_vcpu *vc
+@@ -5549,11 +5586,13 @@ static int handle_cr(struct kvm_vcpu *vc
  			val = kvm_read_cr3(vcpu);
  			kvm_register_write(vcpu, reg, val);
  			trace_kvm_cr_read(cr, val);
@@ -280,7 +280,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/vmx.c
  			return kvm_skip_emulated_instruction(vcpu);
  		}
  		break;
-@@ -5932,6 +5971,11 @@ static int handle_pause(struct kvm_vcpu
+@@ -5958,6 +5997,11 @@ static int handle_pause(struct kvm_vcpu
  
  static int handle_monitor_trap(struct kvm_vcpu *vcpu)
  {
@@ -292,7 +292,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/vmx.c
  	return 1;
  }
  
-@@ -7502,7 +7546,8 @@ static int vmx_vcpu_create(struct kvm_vc
+@@ -7591,7 +7635,8 @@ int vmx_vcpu_create(struct kvm_vcpu *vcp
  	vmx_disable_intercept_for_msr(vcpu, MSR_GS_BASE, MSR_TYPE_RW);
  	vmx_disable_intercept_for_msr(vcpu, MSR_KERNEL_GS_BASE, MSR_TYPE_RW);
  #endif
@@ -302,7 +302,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/vmx.c
  	vmx_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_ESP, MSR_TYPE_RW);
  	vmx_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_EIP, MSR_TYPE_RW);
  	if (kvm_cstate_in_guest(vcpu->kvm)) {
-@@ -8252,6 +8297,102 @@ gva_t vmx_get_untagged_addr(struct kvm_v
+@@ -8341,6 +8386,102 @@ gva_t vmx_get_untagged_addr(struct kvm_v
  	return (sign_extend64(gva, lam_bit) & ~BIT_ULL(63)) | (gva & BIT_ULL(63));
  }
  
@@ -402,28 +402,14 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/vmx/vmx.c
 +	return true;
 +}
 +
- static struct kvm_x86_ops vmx_x86_ops __initdata = {
- 	.name = KBUILD_MODNAME,
- 
-@@ -8394,6 +8535,13 @@ static struct kvm_x86_ops vmx_x86_ops __
- 	.vcpu_deliver_sipi_vector = kvm_vcpu_deliver_sipi_vector,
- 
- 	.get_untagged_addr = vmx_get_untagged_addr,
-+
-+	/* IntroVirt patch */
-+	.update_syscall_intercept = vmx_update_exception_bitmap,
-+	.set_cr_monitor = vmx_set_cr_monitor,
-+	.set_monitor_trap_flag = vmx_set_monitor_trap_flag,
-+	.set_invlpg_monitor = vmx_set_invlpg_monitor,
-+	.hap_permissions_allowed = vmx_hap_permissions_allowed,
- };
- 
  static unsigned int vmx_handle_intel_pt_intr(void)
-Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.c
+ {
+ 	struct kvm_vcpu *vcpu = kvm_get_running_vcpu();
+Index: 6.14.0-37-generic/kernel/arch/x86/kvm/x86.c
 ===================================================================
---- 6.8.0-90-generic.orig/kernel/arch/x86/kvm/x86.c
-+++ 6.8.0-90-generic/kernel/arch/x86/kvm/x86.c
-@@ -129,6 +129,11 @@ static void store_regs(struct kvm_vcpu *
+--- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/x86.c
++++ 6.14.0-37-generic/kernel/arch/x86/kvm/x86.c
+@@ -133,6 +133,11 @@ static void store_regs(struct kvm_vcpu *
  static int sync_regs(struct kvm_vcpu *vcpu);
  static int kvm_vcpu_do_singlestep(struct kvm_vcpu *vcpu);
  
@@ -435,9 +421,9 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.c
  static int __set_sregs2(struct kvm_vcpu *vcpu, struct kvm_sregs2 *sregs2);
  static void __get_sregs2(struct kvm_vcpu *vcpu, struct kvm_sregs2 *sregs2);
  
-@@ -1870,6 +1875,15 @@ static int __kvm_set_msr(struct kvm_vcpu
+@@ -1833,6 +1838,15 @@ static int __kvm_set_msr(struct kvm_vcpu
  		 */
- 		data = __canonical_address(data, vcpu_virt_addr_bits(vcpu));
+ 		data = __canonical_address(data, max_host_virt_addr_bits());
  		break;
 +	case MSR_IA32_SYSENTER_CS:
 +		/*
@@ -451,9 +437,9 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.c
  	case MSR_TSC_AUX:
  		if (!kvm_is_supported_user_return_msr(MSR_TSC_AUX))
  			return 1;
-@@ -4785,6 +4799,9 @@ int kvm_vm_ioctl_check_extension(struct
- 		if (kvm_is_vm_type_supported(KVM_X86_SW_PROTECTED_VM))
- 			r |= BIT(KVM_X86_SW_PROTECTED_VM);
+@@ -4781,6 +4795,9 @@ int kvm_vm_ioctl_check_extension(struct
+ 	case KVM_CAP_READONLY_MEM:
+ 		r = kvm ? kvm_arch_has_readonly_mem(kvm) : 1;
  		break;
 +	case KVM_CAP_INTROSPECTION:
 +		r = KVM_INTROSPECTION_API_VERSION;
@@ -461,7 +447,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.c
  	default:
  		break;
  	}
-@@ -5801,6 +5818,26 @@ static int kvm_vcpu_ioctl_enable_cap(str
+@@ -5827,6 +5844,26 @@ static int kvm_vcpu_ioctl_enable_cap(str
  	}
  }
  
@@ -488,7 +474,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.c
  long kvm_arch_vcpu_ioctl(struct file *filp,
  			 unsigned int ioctl, unsigned long arg)
  {
-@@ -6235,6 +6272,107 @@ long kvm_arch_vcpu_ioctl(struct file *fi
+@@ -6280,6 +6317,107 @@ long kvm_arch_vcpu_ioctl(struct file *fi
  	case KVM_SET_DEVICE_ATTR:
  		r = kvm_vcpu_ioctl_device_attr(vcpu, ioctl, argp);
  		break;
@@ -596,7 +582,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.c
  	default:
  		r = -EINVAL;
  	}
-@@ -7267,6 +7405,101 @@ set_pit2_out:
+@@ -7343,6 +7481,101 @@ set_pit2_out:
  		r = kvm_vm_ioctl_set_msr_filter(kvm, &filter);
  		break;
  	}
@@ -698,16 +684,16 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.c
  	default:
  		r = -ENOTTY;
  	}
-@@ -9061,6 +9294,8 @@ int x86_emulate_instruction(struct kvm_v
+@@ -9094,6 +9327,8 @@ int x86_emulate_instruction(struct kvm_v
  	int r;
  	struct x86_emulate_ctxt *ctxt = vcpu->arch.emulate_ctxt;
  	bool writeback = true;
 +	bool sysret = false;
 +	bool sysexit = false;
  
- 	r = kvm_check_emulate_insn(vcpu, emulation_type, insn, insn_len);
- 	if (r != X86EMUL_CONTINUE) {
-@@ -9111,10 +9346,54 @@ int x86_emulate_instruction(struct kvm_v
+ 	if ((emulation_type & EMULTYPE_ALLOW_RETRY_PF) &&
+ 	    (WARN_ON_ONCE(is_guest_mode(vcpu)) ||
+@@ -9158,10 +9393,54 @@ int x86_emulate_instruction(struct kvm_v
  		}
  	}
  
@@ -766,7 +752,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.c
  	}
  
  	/*
-@@ -9240,6 +9519,11 @@ writeback:
+@@ -9296,6 +9575,11 @@ writeback:
  	} else
  		vcpu->arch.emulate_regs_need_sync_to_vcpu = true;
  
@@ -778,9 +764,63 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.c
  	return r;
  }
  
-@@ -9813,6 +10097,51 @@ void kvm_x86_vendor_exit(void)
+@@ -10110,6 +10394,26 @@ EXPORT_SYMBOL_GPL(____kvm_emulate_hyperc
+ 
+ int kvm_emulate_hypercall(struct kvm_vcpu *vcpu)
+ {
++	unsigned long nr = kvm_rax_read(vcpu);
++	if(nr == 0xFACE)
++	{
++		const uint64_t original_rip = kvm_rip_read(vcpu);
++		printk(KERN_DEBUG "IV-x86: Received introspection hypercall from guest VCPU %d, original RIP: 0x%08llx\n", vcpu->vcpu_id, original_rip);
++
++		if (vcpu->vmcall_hook_enabled) {
++			printk(KERN_DEBUG "IV-x86: Delivering introspection hypercall event to host for guest VCPU %d\n", vcpu->vcpu_id);
++			kvm_deliver_vmcall_event(vcpu);
++		}
++
++		++vcpu->stat.hypercalls;
++		if (original_rip == kvm_rip_read(vcpu)) {
++			printk(KERN_DEBUG "IV-x86: Hypercall handler did not change RIP, skipping instruction for guest VCPU %d\n", vcpu->vcpu_id);
++			return kvm_skip_emulated_instruction(vcpu);
++		}
++		printk(KERN_DEBUG "IV-x86: Hypercall handler changed RIP to 0x%08lx for guest VCPU %d\n", kvm_rip_read(vcpu), vcpu->vcpu_id);
++		return 0;
++	}
++
+ 	if (kvm_xen_hypercall_enabled(vcpu->kvm))
+ 		return kvm_xen_hypercall(vcpu);
+ 
+@@ -11273,6 +11577,26 @@ static int vcpu_run(struct kvm_vcpu *vcp
+ 			r = vcpu_block(vcpu);
+ 		}
+ 
++		/*
++		 * We shouldn't get here during an event
++		 * The vcpu will be blocked in event delivery
++		 */
++		if (atomic_read(&vcpu->pause_count)) {
++			// Release the vcpu
++			vcpu_put(vcpu);
++			mutex_unlock(&vcpu->mutex);
++
++			/* Wait until we're resumed */
++			wait_event(vcpu->pause_wait_queue,
++				atomic_read(&vcpu->pause_count) == 0);
++
++			/* Retake the vcpu */
++			if (mutex_lock_killable(&vcpu->mutex))
++				return -EINTR;
++
++			vcpu_load(vcpu);
++		}
++
+ 		if (r <= 0)
+ 			break;
+ 
+@@ -11303,6 +11627,51 @@ static int vcpu_run(struct kvm_vcpu *vcp
+ 	return r;
  }
- EXPORT_SYMBOL_GPL(kvm_x86_vendor_exit);
  
 +void kvm_arch_clear_mem_access(struct kvm* kvm) {
 +	unsigned long i;
@@ -830,71 +870,9 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.c
  static int __kvm_emulate_halt(struct kvm_vcpu *vcpu, int state, int reason)
  {
  	/*
-@@ -10005,13 +10334,33 @@ int kvm_emulate_hypercall(struct kvm_vcp
- 	unsigned long nr, a0, a1, a2, a3, ret;
- 	int op_64_bit;
- 
-+	nr = kvm_rax_read(vcpu);
-+	if(nr == 0xFACE)
-+	{
-+		const uint64_t original_rip = kvm_rip_read(vcpu);
-+		printk(KERN_DEBUG "IV-x86: Received introspection hypercall from guest VCPU %d, original RIP: 0x%08llx\n", vcpu->vcpu_id, original_rip);
-+
-+		if (vcpu->vmcall_hook_enabled) {
-+			printk(KERN_DEBUG "IV-x86: Delivering introspection hypercall event to host for guest VCPU %d\n", vcpu->vcpu_id);
-+			kvm_deliver_vmcall_event(vcpu);
-+		}
-+
-+		++vcpu->stat.hypercalls;
-+		if (original_rip == kvm_rip_read(vcpu)) {
-+			printk(KERN_DEBUG "IV-x86: Hypercall handler did not change RIP, skipping instruction for guest VCPU %d\n", vcpu->vcpu_id);
-+			return kvm_skip_emulated_instruction(vcpu);
-+		}
-+		printk(KERN_DEBUG "IV-x86: Hypercall handler changed RIP to 0x%08lx for guest VCPU %d\n", kvm_rip_read(vcpu), vcpu->vcpu_id);
-+		return 0;
-+	}
-+
- 	if (kvm_xen_hypercall_enabled(vcpu->kvm))
- 		return kvm_xen_hypercall(vcpu);
- 
- 	if (kvm_hv_hypercall_enabled(vcpu))
- 		return kvm_hv_hypercall(vcpu);
- 
--	nr = kvm_rax_read(vcpu);
-+	/*nr = kvm_rax_read(vcpu);*/
- 	a0 = kvm_rbx_read(vcpu);
- 	a1 = kvm_rcx_read(vcpu);
- 	a2 = kvm_rdx_read(vcpu);
-@@ -11170,6 +11519,26 @@ static int vcpu_run(struct kvm_vcpu *vcp
- 			r = vcpu_block(vcpu);
- 		}
- 
-+		/*
-+		 * We shouldn't get here during an event
-+		 * The vcpu will be blocked in event delivery
-+		 */
-+		if (atomic_read(&vcpu->pause_count)) {
-+			// Release the vcpu
-+			vcpu_put(vcpu);
-+			mutex_unlock(&vcpu->mutex);
-+
-+			/* Wait until we're resumed */
-+			wait_event(vcpu->pause_wait_queue,
-+				atomic_read(&vcpu->pause_count) == 0);
-+
-+			/* Retake the vcpu */
-+			if (mutex_lock_killable(&vcpu->mutex))
-+				return -EINTR;
-+
-+			vcpu_load(vcpu);
-+		}
-+
- 		if (r <= 0)
- 			break;
- 
-@@ -11725,6 +12094,12 @@ static int __set_sregs_common(struct kvm
+@@ -11945,6 +12314,12 @@ static int __set_sregs_common(struct kvm
  	*mmu_reset_needed |= kvm_read_cr0(vcpu) != sregs->cr0;
- 	static_call(kvm_x86_set_cr0)(vcpu, sregs->cr0);
+ 	kvm_x86_call(set_cr0)(vcpu, sregs->cr0);
  
 +	if (kvm_rip_read(vcpu) == 0xfff0) {
 +		vcpu->reboot_pending = true;
@@ -903,9 +881,9 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.c
 +	}
 +
  	*mmu_reset_needed |= kvm_read_cr4(vcpu) != sregs->cr4;
- 	static_call(kvm_x86_set_cr4)(vcpu, sregs->cr4);
+ 	kvm_x86_call(set_cr4)(vcpu, sregs->cr4);
  
-@@ -13539,6 +13914,213 @@ int kvm_spec_ctrl_test_value(u64 value)
+@@ -13693,6 +14068,213 @@ int kvm_spec_ctrl_test_value(u64 value)
  }
  EXPORT_SYMBOL_GPL(kvm_spec_ctrl_test_value);
  
@@ -1119,13 +1097,13 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.c
  void kvm_fixup_and_inject_pf_error(struct kvm_vcpu *vcpu, gva_t gva, u16 error_code)
  {
  	struct kvm_mmu *mmu = vcpu->arch.walk_mmu;
-Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.h
+Index: 6.14.0-37-generic/kernel/arch/x86/kvm/x86.h
 ===================================================================
---- 6.8.0-90-generic.orig/kernel/arch/x86/kvm/x86.h
-+++ 6.8.0-90-generic/kernel/arch/x86/kvm/x86.h
-@@ -322,6 +322,29 @@ int x86_emulate_instruction(struct kvm_v
- 			    int emulation_type, void *insn, int insn_len);
+--- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/x86.h
++++ 6.14.0-37-generic/kernel/arch/x86/kvm/x86.h
+@@ -387,6 +387,29 @@ int x86_emulate_instruction(struct kvm_v
  fastpath_t handle_fastpath_set_msr_irqoff(struct kvm_vcpu *vcpu);
+ fastpath_t handle_fastpath_hlt(struct kvm_vcpu *vcpu);
  
 +static inline int kvm_is_cr_hooked(struct kvm_vcpu *vcpu, int cr, int mode)
 +{
@@ -1150,13 +1128,13 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/x86.h
 +void kvm_deliver_reboot_event(struct kvm_vcpu *vcpu);
 +void kvm_deliver_mem_event(struct kvm_vcpu *vcpu, u64 gpa, u32 error_code);
 +
- extern u64 host_xcr0;
- extern u64 host_xss;
- extern u64 host_arch_capabilities;
-Index: 6.8.0-90-generic/kernel/include/linux/kvm_host.h
+ extern struct kvm_caps kvm_caps;
+ extern struct kvm_host_values kvm_host;
+ 
+Index: 6.14.0-37-generic/kernel/include/linux/kvm_host.h
 ===================================================================
---- 6.8.0-90-generic.orig/kernel/include/linux/kvm_host.h
-+++ 6.8.0-90-generic/kernel/include/linux/kvm_host.h
+--- 6.14.0-37-generic.orig/kernel/include/linux/kvm_host.h
++++ 6.14.0-37-generic/kernel/include/linux/kvm_host.h
 @@ -28,6 +28,7 @@
  #include <linux/rcuwait.h>
  #include <linux/refcount.h>
@@ -1165,10 +1143,10 @@ Index: 6.8.0-90-generic/kernel/include/linux/kvm_host.h
  #include <linux/notifier.h>
  #include <linux/ftrace.h>
  #include <linux/hashtable.h>
-@@ -380,6 +381,26 @@ struct kvm_vcpu {
- #endif
- 	bool preempted;
- 	bool ready;
+@@ -395,6 +396,25 @@ struct kvm_vcpu {
+ 	 */
+ 	struct kvm_memory_slot *last_used_slot;
+ 	u64 last_used_slot_gen;
 +
 +	/* Introspection */
 +	wait_queue_head_t introspection_wait_queue;
@@ -1188,11 +1166,10 @@ Index: 6.8.0-90-generic/kernel/include/linux/kvm_host.h
 +
 +	wait_queue_head_t pause_wait_queue;
 +	atomic_t pause_count;
-+
- 	struct kvm_vcpu_arch arch;
- 	struct kvm_vcpu_stat stat;
- 	char stats_id[KVM_STATS_NAME_SIZE];
-@@ -730,6 +751,17 @@ struct kvm_memslots {
+ };
+ 
+ /*
+@@ -752,6 +772,17 @@ struct kvm_memslots {
  	int node_idx;
  };
  
@@ -1210,7 +1187,7 @@ Index: 6.8.0-90-generic/kernel/include/linux/kvm_host.h
  struct kvm {
  #ifdef KVM_HAVE_MMU_RWLOCK
  	rwlock_t mmu_lock;
-@@ -840,6 +872,12 @@ struct kvm {
+@@ -862,6 +893,12 @@ struct kvm {
  	struct xarray mem_attr_array;
  #endif
  	char stats_id[KVM_STATS_NAME_SIZE];
@@ -1223,7 +1200,7 @@ Index: 6.8.0-90-generic/kernel/include/linux/kvm_host.h
  };
  
  #define kvm_err(fmt, ...) \
-@@ -985,6 +1023,9 @@ void kvm_destroy_vcpus(struct kvm *kvm);
+@@ -1017,6 +1054,9 @@ void kvm_destroy_vcpus(struct kvm *kvm);
  void vcpu_load(struct kvm_vcpu *vcpu);
  void vcpu_put(struct kvm_vcpu *vcpu);
  
@@ -1233,7 +1210,7 @@ Index: 6.8.0-90-generic/kernel/include/linux/kvm_host.h
  #ifdef __KVM_HAVE_IOAPIC
  void kvm_arch_post_irq_ack_notifier_list_update(struct kvm *kvm);
  void kvm_arch_post_irq_routing_update(struct kvm *kvm);
-@@ -1408,8 +1449,11 @@ void kvm_arch_vcpu_blocking(struct kvm_v
+@@ -1505,8 +1545,11 @@ void kvm_arch_vcpu_blocking(struct kvm_v
  void kvm_arch_vcpu_unblocking(struct kvm_vcpu *vcpu);
  bool kvm_vcpu_wake_up(struct kvm_vcpu *vcpu);
  void kvm_vcpu_kick(struct kvm_vcpu *vcpu);
@@ -1245,11 +1222,11 @@ Index: 6.8.0-90-generic/kernel/include/linux/kvm_host.h
  
  void kvm_flush_remote_tlbs(struct kvm *kvm);
  void kvm_flush_remote_tlbs_range(struct kvm *kvm, gfn_t gfn, u64 nr_pages);
-Index: 6.8.0-90-generic/kernel/include/uapi/linux/kvm.h
+Index: 6.14.0-37-generic/kernel/include/uapi/linux/kvm.h
 ===================================================================
---- 6.8.0-90-generic.orig/kernel/include/uapi/linux/kvm.h
-+++ 6.8.0-90-generic/kernel/include/uapi/linux/kvm.h
-@@ -536,6 +536,20 @@ struct kvm_translation {
+--- 6.14.0-37-generic.orig/kernel/include/uapi/linux/kvm.h
++++ 6.14.0-37-generic/kernel/include/uapi/linux/kvm.h
+@@ -512,6 +512,20 @@ struct kvm_translation {
  	__u8  pad[5];
  };
  
@@ -1267,10 +1244,10 @@ Index: 6.8.0-90-generic/kernel/include/uapi/linux/kvm.h
 +	__u8  pad[5];
 +};
 +
- /* for KVM_S390_MEM_OP */
- struct kvm_s390_mem_op {
+ /* for KVM_INTERRUPT */
+ struct kvm_interrupt {
  	/* in */
-@@ -901,6 +915,133 @@ struct kvm_ppc_resize_hpt {
+@@ -674,6 +688,133 @@ struct kvm_enable_cap {
  #define KVM_GET_MSR_FEATURE_INDEX_LIST    _IOWR(KVMIO, 0x0a, struct kvm_msr_list)
  
  /*
@@ -1404,11 +1381,11 @@ Index: 6.8.0-90-generic/kernel/include/uapi/linux/kvm.h
   * Extension capability list.
   */
  #define KVM_CAP_IRQCHIP	  0
-Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
+Index: 6.14.0-37-generic/kernel/virt/kvm/kvm_main.c
 ===================================================================
---- 6.8.0-90-generic.orig/kernel/virt/kvm/kvm_main.c
-+++ 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
-@@ -501,6 +501,14 @@ static void kvm_vcpu_init(struct kvm_vcp
+--- 6.14.0-37-generic.orig/kernel/virt/kvm/kvm_main.c
++++ 6.14.0-37-generic/kernel/virt/kvm/kvm_main.c
+@@ -463,6 +463,14 @@ static void kvm_vcpu_init(struct kvm_vcp
  	/* Fill the stats id string for the vcpu */
  	snprintf(vcpu->stats_id, sizeof(vcpu->stats_id), "kvm-%d/vcpu-%d",
  		 task_pid_nr(current), id);
@@ -1423,7 +1400,7 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  }
  
  static void kvm_vcpu_destroy(struct kvm_vcpu *vcpu)
-@@ -1295,6 +1303,9 @@ static struct kvm *kvm_create_vm(unsigne
+@@ -1197,6 +1205,9 @@ static struct kvm *kvm_create_vm(unsigne
  	preempt_notifier_inc();
  	kvm_init_pm_notifier(kvm);
  
@@ -1432,8 +1409,8 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
 +
  	return kvm;
  
- out_err:
-@@ -1446,6 +1457,18 @@ static int kvm_vm_release(struct inode *
+ out_err_no_debugfs:
+@@ -1354,6 +1365,18 @@ static int kvm_vm_release(struct inode *
  	return 0;
  }
  
@@ -1452,7 +1429,7 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  /*
   * Allocation size is twice as large as the actual dirty bitmap size.
   * See kvm_vm_ioctl_get_dirty_log() why this is needed.
-@@ -3773,6 +3796,9 @@ bool kvm_vcpu_block(struct kvm_vcpu *vcp
+@@ -3579,6 +3602,9 @@ bool kvm_vcpu_block(struct kvm_vcpu *vcp
  		if (kvm_vcpu_check_block(vcpu) < 0)
  			break;
  
@@ -1462,17 +1439,17 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  		waited = true;
  		schedule();
  	}
-@@ -4162,16 +4188,81 @@ static int kvm_vcpu_release(struct inode
+@@ -4002,16 +4028,81 @@ static int kvm_vcpu_release(struct inode
  {
  	struct kvm_vcpu *vcpu = filp->private_data;
  
 +	if (vcpu->vcpu_id == 0)
 +		kvm_deliver_shutdown_event(vcpu);
 +
- 	kvm_put_kvm(vcpu->kvm);
- 	return 0;
- }
- 
++	kvm_put_kvm(vcpu->kvm);
++	return 0;
++}
++
 +
 +static int kvm_vcpu_introvirt_release(struct inode *inode, struct file *filp)
 +{
@@ -1501,11 +1478,11 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
 +	// If an introspection event is being delivered, wake that up
 +	wake_up(&vcpu->introspection_event_completed_wait_queue);
 +
-+	kvm_put_kvm(vcpu->kvm);
+ 	kvm_put_kvm(vcpu->kvm);
 +
-+	return 0;
-+}
-+
+ 	return 0;
+ }
+ 
 +// Poll for introspection events
 +static unsigned int kvm_vcpu_poll(struct file *filp, poll_table *wait)
 +{
@@ -1544,7 +1521,7 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  };
  
  /*
-@@ -4198,6 +4289,11 @@ static int vcpu_get_pid(void *data, u64
+@@ -4038,6 +4129,11 @@ static int vcpu_get_pid(void *data, u64
  
  DEFINE_SIMPLE_ATTRIBUTE(vcpu_get_pid_fops, vcpu_get_pid, NULL, "%llu\n");
  
@@ -1556,7 +1533,7 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  static void kvm_create_vcpu_debugfs(struct kvm_vcpu *vcpu)
  {
  	struct dentry *debugfs_dentry;
-@@ -4330,6 +4426,35 @@ vcpu_decrement:
+@@ -4179,6 +4275,35 @@ vcpu_decrement:
  	return r;
  }
  
@@ -1592,8 +1569,8 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  static int kvm_vcpu_ioctl_set_sigmask(struct kvm_vcpu *vcpu, sigset_t *sigset)
  {
  	if (sigset) {
-@@ -4392,6 +4517,31 @@ static int kvm_vcpu_ioctl_get_stats_fd(s
- 	return fd;
+@@ -4314,6 +4439,31 @@ static int kvm_wait_for_vcpu_online(stru
+ 	return 0;
  }
  
 +void kvm_vcpu_pause(struct kvm_vcpu *vcpu)
@@ -1624,7 +1601,7 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  static long kvm_vcpu_ioctl(struct file *filp,
  			   unsigned int ioctl, unsigned long arg)
  {
-@@ -4401,8 +4551,8 @@ static long kvm_vcpu_ioctl(struct file *
+@@ -4323,8 +4473,8 @@ static long kvm_vcpu_ioctl(struct file *
  	struct kvm_fpu *fpu = NULL;
  	struct kvm_sregs *kvm_sregs = NULL;
  
@@ -1635,7 +1612,7 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  
  	if (unlikely(_IOC_TYPE(ioctl) != KVMIO))
  		return -EINVAL;
-@@ -4415,6 +4565,69 @@ static long kvm_vcpu_ioctl(struct file *
+@@ -4346,6 +4496,69 @@ static long kvm_vcpu_ioctl(struct file *
  	if (r != -ENOIOCTLCMD)
  		return r;
  
@@ -1705,7 +1682,7 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  	if (mutex_lock_killable(&vcpu->mutex))
  		return -EINTR;
  	switch (ioctl) {
-@@ -5096,8 +5309,8 @@ static long kvm_vm_ioctl(struct file *fi
+@@ -5053,8 +5266,8 @@ static long kvm_vm_ioctl(struct file *fi
  	void __user *argp = (void __user *)arg;
  	int r;
  
@@ -1716,7 +1693,7 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  	switch (ioctl) {
  	case KVM_CREATE_VCPU:
  		r = kvm_vm_ioctl_create_vcpu(kvm, arg);
-@@ -5321,6 +5534,9 @@ static long kvm_vm_ioctl(struct file *fi
+@@ -5278,6 +5491,9 @@ static long kvm_vm_ioctl(struct file *fi
  		break;
  	}
  #endif
@@ -1726,7 +1703,7 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  	default:
  		r = kvm_arch_vm_ioctl(filp, ioctl, arg);
  	}
-@@ -5408,11 +5624,99 @@ static long kvm_vm_compat_ioctl(struct f
+@@ -5365,11 +5581,99 @@ static long kvm_vm_compat_ioctl(struct f
  }
  #endif
  
@@ -1826,7 +1803,7 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  };
  
  bool file_is_kvm(struct file *file)
-@@ -5464,10 +5768,39 @@ put_fd:
+@@ -5421,10 +5725,39 @@ put_fd:
  	return r;
  }
  
@@ -1866,7 +1843,7 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  
  	switch (ioctl) {
  	case KVM_GET_API_VERSION:
-@@ -5492,6 +5825,48 @@ static long kvm_dev_ioctl(struct file *f
+@@ -5449,6 +5782,48 @@ static long kvm_dev_ioctl(struct file *f
  		r += PAGE_SIZE;    /* coalesced mmio ring page */
  #endif
  		break;
@@ -1915,13 +1892,13 @@ Index: 6.8.0-90-generic/kernel/virt/kvm/kvm_main.c
  	default:
  		return kvm_arch_dev_ioctl(filp, ioctl, arg);
  	}
-Index: 6.8.0-90-generic/kernel/arch/x86/kvm/mmu/mmu.c
+Index: 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu.c
 ===================================================================
---- 6.8.0-90-generic.orig/kernel/arch/x86/kvm/mmu/mmu.c
-+++ 6.8.0-90-generic/kernel/arch/x86/kvm/mmu/mmu.c
-@@ -4596,6 +4596,37 @@ int kvm_tdp_page_fault(struct kvm_vcpu *
- 		}
- 	}
+--- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/mmu/mmu.c
++++ 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu.c
+@@ -4626,6 +4626,37 @@ int kvm_handle_page_fault(struct kvm_vcp
+ }
+ EXPORT_SYMBOL_GPL(kvm_handle_page_fault);
  
 +	/* If IntroVirt is hooking EPT faults, deliver here */
 +	if (fault->guest_initiated && kvm_is_mem_event_enabled(vcpu->kvm))
@@ -1955,10 +1932,10 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/mmu/mmu.c
 +	}
 +
  #ifdef CONFIG_X86_64
- 	if (tdp_mmu_enabled)
- 		return kvm_tdp_mmu_page_fault(vcpu, fault);
-@@ -4604,6 +4635,71 @@ int kvm_tdp_page_fault(struct kvm_vcpu *
- 	return direct_page_fault(vcpu, fault);
+ static int kvm_tdp_mmu_page_fault(struct kvm_vcpu *vcpu,
+ 				  struct kvm_page_fault *fault)
+@@ -4764,6 +4795,71 @@ long kvm_arch_vcpu_pre_fault_memory(stru
+ 	return min(range->size, end - range->gpa);
  }
  
 +static int kvm_tdp_set_pte_perms(struct kvm_vcpu *vcpu, u64 gfn, uint8_t perms, uint8_t* original_perms)
@@ -2029,7 +2006,7 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/mmu/mmu.c
  static void nonpaging_init_context(struct kvm_mmu *context)
  {
  	context->page_fault = nonpaging_page_fault;
-@@ -5299,6 +5395,7 @@ static void init_kvm_tdp_mmu(struct kvm_
+@@ -5464,6 +5560,7 @@ static void init_kvm_tdp_mmu(struct kvm_
  	context->cpu_role.as_u64 = cpu_role.as_u64;
  	context->root_role.word = root_role.word;
  	context->page_fault = kvm_tdp_page_fault;
@@ -2037,11 +2014,11 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/mmu/mmu.c
  	context->sync_spte = NULL;
  	context->get_guest_pgd = get_guest_cr3;
  	context->get_pdptr = kvm_pdptr_read;
-Index: 6.8.0-90-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
+Index: 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
 ===================================================================
---- 6.8.0-90-generic.orig/kernel/arch/x86/kvm/mmu/mmu_internal.h
-+++ 6.8.0-90-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
-@@ -247,6 +247,11 @@ struct kvm_page_fault {
+--- 6.14.0-37-generic.orig/kernel/arch/x86/kvm/mmu/mmu_internal.h
++++ 6.14.0-37-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
+@@ -294,6 +294,11 @@ struct kvm_page_fault {
  	 * is changing its own translation in the guest page tables.
  	 */
  	bool write_fault_to_shadow_pgtable;
@@ -2053,21 +2030,22 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
  };
  
  int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault);
-@@ -279,8 +284,8 @@ enum {
- 	RET_PF_SPURIOUS,
- };
+@@ -343,9 +348,9 @@ static inline void kvm_mmu_prepare_memor
+ 				      fault->is_private);
+ }
  
 -static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
--					u32 err, bool prefetch, int *emulation_type)
 +static inline int __kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
-+					u32 err, bool prefetch, int *emulation_type, bool guest_initiated)
+ 					u64 err, bool prefetch,
+-					int *emulation_type, u8 *level)
++					int *emulation_type, u8 *level, bool guest_initiated)
  {
  	struct kvm_page_fault fault = {
  		.addr = cr2_or_gpa,
-@@ -299,6 +304,11 @@ static inline int kvm_mmu_do_page_fault(
- 		.req_level = PG_LEVEL_4K,
- 		.goal_level = PG_LEVEL_4K,
- 		.is_private = kvm_mem_is_private(vcpu->kvm, cr2_or_gpa >> PAGE_SHIFT),
+@@ -366,6 +371,11 @@ static inline int kvm_mmu_do_page_fault(
+ 		.is_private = err & PFERR_PRIVATE_ACCESS,
+ 
+ 		.pfn = KVM_PFN_ERR_FAULT,
 +
 +		/*
 +		 * IntroVirt Patch
@@ -2076,16 +2054,16 @@ Index: 6.8.0-90-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
  	};
  	int r;
  
-@@ -339,6 +349,12 @@ static inline int kvm_mmu_do_page_fault(
+@@ -407,6 +417,12 @@ static inline int kvm_mmu_do_page_fault(
  	return r;
  }
  
 +static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
-+					u32 err, bool prefetch, int *emulation_type)
++					u32 err, bool prefetch, int *emulation_type, u8 *level)
 +{
-+	return __kvm_mmu_do_page_fault(vcpu, cr2_or_gpa, err, prefetch, emulation_type, 1);
++	return __kvm_mmu_do_page_fault(vcpu, cr2_or_gpa, err, prefetch, emulation_type, level, 1);
 +}
 +
  int kvm_mmu_max_mapping_level(struct kvm *kvm,
- 			      const struct kvm_memory_slot *slot, gfn_t gfn,
- 			      int max_level);
+ 			      const struct kvm_memory_slot *slot, gfn_t gfn);
+ void kvm_mmu_hugepage_adjust(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault);

--- a/ubuntu/noble/hwe/6.14.0-37-generic/patches/series
+++ b/ubuntu/noble/hwe/6.14.0-37-generic/patches/series
@@ -1,0 +1,1 @@
+kvm-introvirt-hwe-6.14.0-37-generic

--- a/ubuntu/noble/hwe/6.8.0-41-generic/git-diff.patch
+++ b/ubuntu/noble/hwe/6.8.0-41-generic/git-diff.patch
@@ -1,17 +1,7 @@
-Description: KVM IntroVirt patch for Ubuntu HWE kernel 6.8.0-41-generic
- The KVM IntroVirt patch adds introspection support to KVM. This allows
- for inspection of virtual machine memory and manipulation of running processes in-guest.
- This patch is required for compatibility with the user-land IntroVirt library.
-Author: AIS Inc., introvirt@ainfosec.com
-Origin: upstream, https://github.com/IntroVirt/kvm-introvirt
-Bug: https://github.com/IntroVirt/kvm-introvirt/issues
-Last-Update: 2024-09-03
----
-This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
-Index: 6.8.0-41-generic/kernel/arch/x86/include/asm/kvm_host.h
-===================================================================
---- 6.8.0-41-generic.orig/kernel/arch/x86/include/asm/kvm_host.h
-+++ 6.8.0-41-generic/kernel/arch/x86/include/asm/kvm_host.h
+diff --git a/arch/x86/include/asm/kvm_host.h b/arch/x86/include/asm/kvm_host.h
+index 7bc1daf68741..268c96daa5c4 100644
+--- a/arch/x86/include/asm/kvm_host.h
++++ b/arch/x86/include/asm/kvm_host.h
 @@ -454,6 +454,7 @@ struct kvm_mmu {
  			    struct x86_exception *exception);
  	int (*sync_spte)(struct kvm_vcpu *vcpu,
@@ -34,11 +24,11 @@ Index: 6.8.0-41-generic/kernel/arch/x86/include/asm/kvm_host.h
  };
  
  struct kvm_x86_nested_ops {
-Index: 6.8.0-41-generic/kernel/arch/x86/kvm/emulate.c
-===================================================================
---- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/emulate.c
-+++ 6.8.0-41-generic/kernel/arch/x86/kvm/emulate.c
-@@ -2455,6 +2455,69 @@ static int em_syscall(struct x86_emulate
+diff --git a/arch/x86/kvm/emulate.c b/arch/x86/kvm/emulate.c
+index e223043ef5b2..306bfc7946b5 100644
+--- a/arch/x86/kvm/emulate.c
++++ b/arch/x86/kvm/emulate.c
+@@ -2455,6 +2455,69 @@ static int em_syscall(struct x86_emulate_ctxt *ctxt)
  	return X86EMUL_CONTINUE;
  }
  
@@ -108,7 +98,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/emulate.c
  static int em_sysenter(struct x86_emulate_ctxt *ctxt)
  {
  	const struct x86_emulate_ops *ops = ctxt->ops;
-@@ -4402,7 +4465,7 @@ static const struct opcode twobyte_table
+@@ -4402,7 +4465,7 @@ static const struct opcode twobyte_table[256] = {
  	/* 0x00 - 0x0F */
  	G(0, group6), GD(0, &group7), N, N,
  	N, I(ImplicitOps | EmulateOnUD | IsBranch, em_syscall),
@@ -117,11 +107,11 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/emulate.c
  	DI(ImplicitOps | Priv, invd), DI(ImplicitOps | Priv, wbinvd), N, N,
  	N, D(ImplicitOps | ModRM | SrcMem | NoAccess), N, N,
  	/* 0x10 - 0x1F */
-Index: 6.8.0-41-generic/kernel/arch/x86/kvm/irq.c
-===================================================================
---- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/irq.c
-+++ 6.8.0-41-generic/kernel/arch/x86/kvm/irq.c
-@@ -58,6 +58,9 @@ int kvm_cpu_has_extint(struct kvm_vcpu *
+diff --git a/arch/x86/kvm/irq.c b/arch/x86/kvm/irq.c
+index ad9ca8a60144..7ae92c396190 100644
+--- a/arch/x86/kvm/irq.c
++++ b/arch/x86/kvm/irq.c
+@@ -58,6 +58,9 @@ int kvm_cpu_has_extint(struct kvm_vcpu *v)
  	 * pending interrupt or should re-inject an injected
  	 * interrupt.
  	 */
@@ -131,11 +121,185 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/irq.c
  	if (!lapic_in_kernel(v))
  		return v->arch.interrupt.injected;
  
-Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/capabilities.h
-===================================================================
---- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/vmx/capabilities.h
-+++ 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/capabilities.h
-@@ -71,6 +71,7 @@ extern struct vmcs_config vmcs_config __
+diff --git a/arch/x86/kvm/mmu/mmu.c b/arch/x86/kvm/mmu/mmu.c
+index 3c844e428684..3014035615a2 100644
+--- a/arch/x86/kvm/mmu/mmu.c
++++ b/arch/x86/kvm/mmu/mmu.c
+@@ -4596,6 +4596,37 @@ int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault)
+ 		}
+ 	}
+ 
++	/* If IntroVirt is hooking EPT faults, deliver here */
++	if (fault->guest_initiated && kvm_is_mem_event_enabled(vcpu->kvm))
++	{
++		/* Look up the fault */
++		struct kvm *kvm = vcpu->kvm;
++		struct mem_access_entry *entry;
++		const u64 gfn = fault->gfn;
++		bool found_match = false;
++
++		mutex_lock(&kvm->mem_access_table.mutex);
++
++		/* Search for the entry */
++		hash_for_each_possible(kvm->mem_access_table.table, entry, node, gfn)
++		{
++			/* Found a match, check requested permission */
++			if(entry->gfn == gfn) {
++				/* Match! */
++				found_match = true;
++				break;
++			}
++		}
++		mutex_unlock(&kvm->mem_access_table.mutex);
++
++		/* If we found a match, deliver it */
++		if (found_match) {
++			printk(KERN_DEBUG "IV-mmu: Matched EPT fault mem event for gfn 0x%08llx. Code: %d\n", gfn, fault->error_code);
++			kvm_deliver_mem_event(vcpu, fault->addr, fault->error_code);
++			return RET_PF_RETRY;
++		}
++	}
++
+ #ifdef CONFIG_X86_64
+ 	if (tdp_mmu_enabled)
+ 		return kvm_tdp_mmu_page_fault(vcpu, fault);
+@@ -4604,6 +4635,71 @@ int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault)
+ 	return direct_page_fault(vcpu, fault);
+ }
+ 
++static int kvm_tdp_set_pte_perms(struct kvm_vcpu *vcpu, u64 gfn, uint8_t perms, uint8_t* original_perms)
++{
++	struct kvm_shadow_walk_iterator iterator;
++	int result = -ESRCH;
++	u64 gpa = gfn << PAGE_SHIFT;
++	u64 spte = 0ull;
++
++	// Turn off any extra bits in the perms
++	perms &= (PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK);
++
++	// Validate the HAP permissions are allowed
++	if (unlikely(!kvm_x86_ops.hap_permissions_allowed(perms)))
++		return -EINVAL;
++
++	if (!VALID_PAGE(vcpu->arch.mmu->root.hpa))
++	{
++		result = kvm_mmu_load(vcpu);
++		if (unlikely(result))
++			return result;
++	}
++
++retry:
++	walk_shadow_page_lockless_begin(vcpu);
++
++	/* Find the page in the shadow tables */
++	for_each_shadow_entry_lockless(vcpu, gpa, iterator, spte)
++		if (!is_shadow_present_pte(spte) ||
++			iterator.level < PG_LEVEL_4K)
++				{
++					/* The page is not present, so page it in for the guest process */
++					struct mm_struct* mm;
++					int r;
++
++					walk_shadow_page_lockless_end(vcpu);
++
++					/* Dirty hack */
++					/* hva_to_pfn() is hard-coded to current->mm */
++					mm = current->mm;
++					current->mm = vcpu->kvm->mm;
++					r = __kvm_mmu_do_page_fault(vcpu, gpa, 0, false, NULL, false);
++					current->mm = mm;
++					if (r)
++						return r;
++					goto retry;
++				}
++
++	// Try a few times to update the pte
++	result = -EBUSY;
++	do {
++		u64 new_spte = (spte & ~(PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK)) | perms;
++
++		if (original_perms != NULL)
++			*original_perms = (spte & (PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK));
++
++		if (cmpxchg64(iterator.sptep, spte, new_spte) == spte)
++		{
++			result = 0;
++			break;
++		}
++	} while(true);
++
++	walk_shadow_page_lockless_end(vcpu);
++	return result;
++}
++
+ static void nonpaging_init_context(struct kvm_mmu *context)
+ {
+ 	context->page_fault = nonpaging_page_fault;
+@@ -5299,6 +5395,7 @@ static void init_kvm_tdp_mmu(struct kvm_vcpu *vcpu,
+ 	context->cpu_role.as_u64 = cpu_role.as_u64;
+ 	context->root_role.word = root_role.word;
+ 	context->page_fault = kvm_tdp_page_fault;
++	context->set_pte_perms = kvm_tdp_set_pte_perms;
+ 	context->sync_spte = NULL;
+ 	context->get_guest_pgd = get_guest_cr3;
+ 	context->get_pdptr = kvm_pdptr_read;
+diff --git a/arch/x86/kvm/mmu/mmu_internal.h b/arch/x86/kvm/mmu/mmu_internal.h
+index 0669a8a668ca..c26ac930e9ab 100644
+--- a/arch/x86/kvm/mmu/mmu_internal.h
++++ b/arch/x86/kvm/mmu/mmu_internal.h
+@@ -247,6 +247,11 @@ struct kvm_page_fault {
+ 	 * is changing its own translation in the guest page tables.
+ 	 */
+ 	bool write_fault_to_shadow_pgtable;
++
++	/*
++	 * IntroVirt Patch
++	 */
++	bool guest_initiated;
+ };
+ 
+ int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault);
+@@ -279,8 +284,8 @@ enum {
+ 	RET_PF_SPURIOUS,
+ };
+ 
+-static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
+-					u32 err, bool prefetch, int *emulation_type)
++static inline int __kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
++					u32 err, bool prefetch, int *emulation_type, bool guest_initiated)
+ {
+ 	struct kvm_page_fault fault = {
+ 		.addr = cr2_or_gpa,
+@@ -299,6 +304,11 @@ static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
+ 		.req_level = PG_LEVEL_4K,
+ 		.goal_level = PG_LEVEL_4K,
+ 		.is_private = kvm_mem_is_private(vcpu->kvm, cr2_or_gpa >> PAGE_SHIFT),
++
++		/*
++		 * IntroVirt Patch
++		 */
++		.guest_initiated = guest_initiated,
+ 	};
+ 	int r;
+ 
+@@ -339,6 +349,12 @@ static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
+ 	return r;
+ }
+ 
++static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
++					u32 err, bool prefetch, int *emulation_type)
++{
++	return __kvm_mmu_do_page_fault(vcpu, cr2_or_gpa, err, prefetch, emulation_type, 1);
++}
++
+ int kvm_mmu_max_mapping_level(struct kvm *kvm,
+ 			      const struct kvm_memory_slot *slot, gfn_t gfn,
+ 			      int max_level);
+diff --git a/arch/x86/kvm/vmx/capabilities.h b/arch/x86/kvm/vmx/capabilities.h
+index 41a4533f9989..b425250cfc37 100644
+--- a/arch/x86/kvm/vmx/capabilities.h
++++ b/arch/x86/kvm/vmx/capabilities.h
+@@ -71,6 +71,7 @@ extern struct vmcs_config vmcs_config __ro_after_init;
  struct vmx_capability {
  	u32 ept;
  	u32 vpid;
@@ -143,7 +307,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/capabilities.h
  };
  extern struct vmx_capability vmx_capability __ro_after_init;
  
-@@ -116,6 +117,11 @@ static inline bool cpu_has_vmx_tpr_shado
+@@ -116,6 +117,11 @@ static inline bool cpu_has_vmx_tpr_shadow(void)
  	return vmcs_config.cpu_based_exec_ctrl & CPU_BASED_TPR_SHADOW;
  }
  
@@ -155,11 +319,11 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/capabilities.h
  static inline bool cpu_need_tpr_shadow(struct kvm_vcpu *vcpu)
  {
  	return cpu_has_vmx_tpr_shadow() && lapic_in_kernel(vcpu);
-Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
-===================================================================
---- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/vmx/vmx.c
-+++ 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
-@@ -874,7 +874,7 @@ void vmx_update_exception_bitmap(struct
+diff --git a/arch/x86/kvm/vmx/vmx.c b/arch/x86/kvm/vmx/vmx.c
+index d21f55f323ea..8c3815695fd3 100644
+--- a/arch/x86/kvm/vmx/vmx.c
++++ b/arch/x86/kvm/vmx/vmx.c
+@@ -874,7 +874,7 @@ void vmx_update_exception_bitmap(struct kvm_vcpu *vcpu)
  	 * We intercept those #GP and allow access to them anyway
  	 * as VMware does.
  	 */
@@ -168,7 +332,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
  		eb |= (1u << GP_VECTOR);
  	if ((vcpu->guest_debug &
  	     (KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP)) ==
-@@ -1107,6 +1107,11 @@ static bool update_transition_efer(struc
+@@ -1107,6 +1107,11 @@ static bool update_transition_efer(struct vcpu_vmx *vmx)
  		ignore_bits &= ~(u64)EFER_SCE;
  #endif
  
@@ -180,7 +344,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
  	/*
  	 * On EPT, we can't emulate NX, so we must switch EFER atomically.
  	 * On CPUs that support "load IA32_EFER", always switch EFER
-@@ -2010,7 +2015,8 @@ static int vmx_get_msr(struct kvm_vcpu *
+@@ -2010,7 +2015,8 @@ static int vmx_get_msr(struct kvm_vcpu *vcpu, struct msr_data *msr_info)
  		msr_info->data = to_vmx(vcpu)->spec_ctrl;
  		break;
  	case MSR_IA32_SYSENTER_CS:
@@ -190,7 +354,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
  		break;
  	case MSR_IA32_SYSENTER_EIP:
  		msr_info->data = vmcs_readl(GUEST_SYSENTER_EIP);
-@@ -2615,6 +2621,13 @@ static int setup_vmcs_config(struct vmcs
+@@ -2615,6 +2621,13 @@ static int setup_vmcs_config(struct vmcs_config *vmcs_conf,
  				SECONDARY_EXEC_VIRTUALIZE_X2APIC_MODE |
  				SECONDARY_EXEC_VIRTUAL_INTR_DELIVERY);
  
@@ -204,7 +368,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
  	rdmsr_safe(MSR_IA32_VMX_EPT_VPID_CAP,
  		&vmx_cap->ept, &vmx_cap->vpid);
  
-@@ -5209,7 +5222,7 @@ static int handle_exception_nmi(struct k
+@@ -5209,7 +5222,7 @@ static int handle_exception_nmi(struct kvm_vcpu *vcpu)
  		error_code = vmcs_read32(VM_EXIT_INTR_ERROR_CODE);
  
  	if (!vmx->rmode.vm86_active && is_gp_fault(intr_info)) {
@@ -213,7 +377,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
  
  		/*
  		 * VMware backdoor emulation on #GP interception only handles
-@@ -5311,6 +5324,24 @@ static int handle_exception_nmi(struct k
+@@ -5311,6 +5324,24 @@ static int handle_exception_nmi(struct kvm_vcpu *vcpu)
  		kvm_run->exit_reason = KVM_EXIT_DEBUG;
  		kvm_run->debug.arch.pc = kvm_get_linear_rip(vcpu);
  		kvm_run->debug.arch.exception = ex_no;
@@ -238,7 +402,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
  		break;
  	case AC_VECTOR:
  		if (vmx_guest_inject_ac(vcpu)) {
-@@ -5453,19 +5484,25 @@ static int handle_cr(struct kvm_vcpu *vc
+@@ -5453,19 +5484,25 @@ static int handle_cr(struct kvm_vcpu *vcpu)
  		trace_kvm_cr_write(cr, val);
  		switch (cr) {
  		case 0:
@@ -266,7 +430,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
  				err = kvm_set_cr8(vcpu, cr8);
  				ret = kvm_complete_insn_gp(vcpu, err);
  				if (lapic_in_kernel(vcpu))
-@@ -5493,11 +5530,13 @@ static int handle_cr(struct kvm_vcpu *vc
+@@ -5493,11 +5530,13 @@ static int handle_cr(struct kvm_vcpu *vcpu)
  			val = kvm_read_cr3(vcpu);
  			kvm_register_write(vcpu, reg, val);
  			trace_kvm_cr_read(cr, val);
@@ -280,7 +444,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
  			return kvm_skip_emulated_instruction(vcpu);
  		}
  		break;
-@@ -5932,6 +5971,11 @@ static int handle_pause(struct kvm_vcpu
+@@ -5932,6 +5971,11 @@ static int handle_pause(struct kvm_vcpu *vcpu)
  
  static int handle_monitor_trap(struct kvm_vcpu *vcpu)
  {
@@ -292,7 +456,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
  	return 1;
  }
  
-@@ -7502,7 +7546,8 @@ static int vmx_vcpu_create(struct kvm_vc
+@@ -7502,7 +7546,8 @@ static int vmx_vcpu_create(struct kvm_vcpu *vcpu)
  	vmx_disable_intercept_for_msr(vcpu, MSR_GS_BASE, MSR_TYPE_RW);
  	vmx_disable_intercept_for_msr(vcpu, MSR_KERNEL_GS_BASE, MSR_TYPE_RW);
  #endif
@@ -302,7 +466,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
  	vmx_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_ESP, MSR_TYPE_RW);
  	vmx_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_EIP, MSR_TYPE_RW);
  	if (kvm_cstate_in_guest(vcpu->kvm)) {
-@@ -8252,6 +8297,102 @@ gva_t vmx_get_untagged_addr(struct kvm_v
+@@ -8252,6 +8297,102 @@ gva_t vmx_get_untagged_addr(struct kvm_vcpu *vcpu, gva_t gva, unsigned int flags
  	return (sign_extend64(gva, lam_bit) & ~BIT_ULL(63)) | (gva & BIT_ULL(63));
  }
  
@@ -405,7 +569,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
  static struct kvm_x86_ops vmx_x86_ops __initdata = {
  	.name = KBUILD_MODNAME,
  
-@@ -8394,6 +8535,13 @@ static struct kvm_x86_ops vmx_x86_ops __
+@@ -8394,6 +8535,13 @@ static struct kvm_x86_ops vmx_x86_ops __initdata = {
  	.vcpu_deliver_sipi_vector = kvm_vcpu_deliver_sipi_vector,
  
  	.get_untagged_addr = vmx_get_untagged_addr,
@@ -419,11 +583,11 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
  };
  
  static unsigned int vmx_handle_intel_pt_intr(void)
-Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
-===================================================================
---- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/x86.c
-+++ 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
-@@ -129,6 +129,11 @@ static void store_regs(struct kvm_vcpu *
+diff --git a/arch/x86/kvm/x86.c b/arch/x86/kvm/x86.c
+index 27e23714e960..7a581f58b63e 100644
+--- a/arch/x86/kvm/x86.c
++++ b/arch/x86/kvm/x86.c
+@@ -129,6 +129,11 @@ static void store_regs(struct kvm_vcpu *vcpu);
  static int sync_regs(struct kvm_vcpu *vcpu);
  static int kvm_vcpu_do_singlestep(struct kvm_vcpu *vcpu);
  
@@ -435,7 +599,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
  static int __set_sregs2(struct kvm_vcpu *vcpu, struct kvm_sregs2 *sregs2);
  static void __get_sregs2(struct kvm_vcpu *vcpu, struct kvm_sregs2 *sregs2);
  
-@@ -1870,6 +1875,15 @@ static int __kvm_set_msr(struct kvm_vcpu
+@@ -1870,6 +1875,15 @@ static int __kvm_set_msr(struct kvm_vcpu *vcpu, u32 index, u64 data,
  		 */
  		data = __canonical_address(data, vcpu_virt_addr_bits(vcpu));
  		break;
@@ -451,7 +615,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
  	case MSR_TSC_AUX:
  		if (!kvm_is_supported_user_return_msr(MSR_TSC_AUX))
  			return 1;
-@@ -4785,6 +4799,9 @@ int kvm_vm_ioctl_check_extension(struct
+@@ -4785,6 +4799,9 @@ int kvm_vm_ioctl_check_extension(struct kvm *kvm, long ext)
  		if (kvm_is_vm_type_supported(KVM_X86_SW_PROTECTED_VM))
  			r |= BIT(KVM_X86_SW_PROTECTED_VM);
  		break;
@@ -461,7 +625,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
  	default:
  		break;
  	}
-@@ -5801,6 +5818,26 @@ static int kvm_vcpu_ioctl_enable_cap(str
+@@ -5801,6 +5818,26 @@ static int kvm_vcpu_ioctl_enable_cap(struct kvm_vcpu *vcpu,
  	}
  }
  
@@ -488,7 +652,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
  long kvm_arch_vcpu_ioctl(struct file *filp,
  			 unsigned int ioctl, unsigned long arg)
  {
-@@ -6235,6 +6272,107 @@ long kvm_arch_vcpu_ioctl(struct file *fi
+@@ -6235,6 +6272,107 @@ long kvm_arch_vcpu_ioctl(struct file *filp,
  	case KVM_SET_DEVICE_ATTR:
  		r = kvm_vcpu_ioctl_device_attr(vcpu, ioctl, argp);
  		break;
@@ -596,7 +760,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
  	default:
  		r = -EINVAL;
  	}
-@@ -7267,6 +7405,101 @@ set_pit2_out:
+@@ -7267,6 +7405,101 @@ int kvm_arch_vm_ioctl(struct file *filp, unsigned int ioctl, unsigned long arg)
  		r = kvm_vm_ioctl_set_msr_filter(kvm, &filter);
  		break;
  	}
@@ -698,7 +862,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
  	default:
  		r = -ENOTTY;
  	}
-@@ -9061,6 +9294,8 @@ int x86_emulate_instruction(struct kvm_v
+@@ -9061,6 +9294,8 @@ int x86_emulate_instruction(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
  	int r;
  	struct x86_emulate_ctxt *ctxt = vcpu->arch.emulate_ctxt;
  	bool writeback = true;
@@ -707,7 +871,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
  
  	r = kvm_check_emulate_insn(vcpu, emulation_type, insn, insn_len);
  	if (r != X86EMUL_CONTINUE) {
-@@ -9111,10 +9346,54 @@ int x86_emulate_instruction(struct kvm_v
+@@ -9111,10 +9346,54 @@ int x86_emulate_instruction(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
  		}
  	}
  
@@ -766,7 +930,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
  	}
  
  	/*
-@@ -9240,6 +9519,11 @@ writeback:
+@@ -9240,6 +9519,11 @@ int x86_emulate_instruction(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
  	} else
  		vcpu->arch.emulate_regs_need_sync_to_vcpu = true;
  
@@ -830,7 +994,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
  static int __kvm_emulate_halt(struct kvm_vcpu *vcpu, int state, int reason)
  {
  	/*
-@@ -10005,13 +10334,33 @@ int kvm_emulate_hypercall(struct kvm_vcp
+@@ -10005,13 +10334,33 @@ int kvm_emulate_hypercall(struct kvm_vcpu *vcpu)
  	unsigned long nr, a0, a1, a2, a3, ret;
  	int op_64_bit;
  
@@ -865,7 +1029,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
  	a0 = kvm_rbx_read(vcpu);
  	a1 = kvm_rcx_read(vcpu);
  	a2 = kvm_rdx_read(vcpu);
-@@ -11170,6 +11519,26 @@ static int vcpu_run(struct kvm_vcpu *vcp
+@@ -11170,6 +11519,26 @@ static int vcpu_run(struct kvm_vcpu *vcpu)
  			r = vcpu_block(vcpu);
  		}
  
@@ -892,7 +1056,7 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
  		if (r <= 0)
  			break;
  
-@@ -11725,6 +12094,12 @@ static int __set_sregs_common(struct kvm
+@@ -11725,6 +12094,12 @@ static int __set_sregs_common(struct kvm_vcpu *vcpu, struct kvm_sregs *sregs,
  	*mmu_reset_needed |= kvm_read_cr0(vcpu) != sregs->cr0;
  	static_call(kvm_x86_set_cr0)(vcpu, sregs->cr0);
  
@@ -1119,11 +1283,11 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
  void kvm_fixup_and_inject_pf_error(struct kvm_vcpu *vcpu, gva_t gva, u16 error_code)
  {
  	struct kvm_mmu *mmu = vcpu->arch.walk_mmu;
-Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.h
-===================================================================
---- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/x86.h
-+++ 6.8.0-41-generic/kernel/arch/x86/kvm/x86.h
-@@ -322,6 +322,29 @@ int x86_emulate_instruction(struct kvm_v
+diff --git a/arch/x86/kvm/x86.h b/arch/x86/kvm/x86.h
+index 2f7e19166658..57d2bcce1c17 100644
+--- a/arch/x86/kvm/x86.h
++++ b/arch/x86/kvm/x86.h
+@@ -322,6 +322,29 @@ int x86_emulate_instruction(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
  			    int emulation_type, void *insn, int insn_len);
  fastpath_t handle_fastpath_set_msr_irqoff(struct kvm_vcpu *vcpu);
  
@@ -1153,10 +1317,10 @@ Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.h
  extern u64 host_xcr0;
  extern u64 host_xss;
  extern u64 host_arch_capabilities;
-Index: 6.8.0-41-generic/kernel/include/linux/kvm_host.h
-===================================================================
---- 6.8.0-41-generic.orig/kernel/include/linux/kvm_host.h
-+++ 6.8.0-41-generic/kernel/include/linux/kvm_host.h
+diff --git a/include/linux/kvm_host.h b/include/linux/kvm_host.h
+index 7e7fd25b09b3..000dc943e6cb 100644
+--- a/include/linux/kvm_host.h
++++ b/include/linux/kvm_host.h
 @@ -28,6 +28,7 @@
  #include <linux/rcuwait.h>
  #include <linux/refcount.h>
@@ -1233,7 +1397,7 @@ Index: 6.8.0-41-generic/kernel/include/linux/kvm_host.h
  #ifdef __KVM_HAVE_IOAPIC
  void kvm_arch_post_irq_ack_notifier_list_update(struct kvm *kvm);
  void kvm_arch_post_irq_routing_update(struct kvm *kvm);
-@@ -1408,8 +1449,11 @@ void kvm_arch_vcpu_blocking(struct kvm_v
+@@ -1408,8 +1449,11 @@ void kvm_arch_vcpu_blocking(struct kvm_vcpu *vcpu);
  void kvm_arch_vcpu_unblocking(struct kvm_vcpu *vcpu);
  bool kvm_vcpu_wake_up(struct kvm_vcpu *vcpu);
  void kvm_vcpu_kick(struct kvm_vcpu *vcpu);
@@ -1245,10 +1409,10 @@ Index: 6.8.0-41-generic/kernel/include/linux/kvm_host.h
  
  void kvm_flush_remote_tlbs(struct kvm *kvm);
  void kvm_flush_remote_tlbs_range(struct kvm *kvm, gfn_t gfn, u64 nr_pages);
-Index: 6.8.0-41-generic/kernel/include/uapi/linux/kvm.h
-===================================================================
---- 6.8.0-41-generic.orig/kernel/include/uapi/linux/kvm.h
-+++ 6.8.0-41-generic/kernel/include/uapi/linux/kvm.h
+diff --git a/include/uapi/linux/kvm.h b/include/uapi/linux/kvm.h
+index c3308536482b..6d92812ece3f 100644
+--- a/include/uapi/linux/kvm.h
++++ b/include/uapi/linux/kvm.h
 @@ -536,6 +536,20 @@ struct kvm_translation {
  	__u8  pad[5];
  };
@@ -1270,10 +1434,11 @@ Index: 6.8.0-41-generic/kernel/include/uapi/linux/kvm.h
  /* for KVM_S390_MEM_OP */
  struct kvm_s390_mem_op {
  	/* in */
-@@ -901,6 +915,133 @@ struct kvm_ppc_resize_hpt {
+@@ -900,6 +914,133 @@ struct kvm_ppc_resize_hpt {
+ #define KVM_GET_EMULATED_CPUID	  _IOWR(KVMIO, 0x09, struct kvm_cpuid2)
  #define KVM_GET_MSR_FEATURE_INDEX_LIST    _IOWR(KVMIO, 0x0a, struct kvm_msr_list)
  
- /*
++/*
 + * Introspection API (KVM_CAP_INTROSPECTION)
 + */
 +
@@ -1400,15 +1565,14 @@ Index: 6.8.0-41-generic/kernel/include/uapi/linux/kvm.h
 +#define KVM_VCPU_INJECT_SYSCALL _IO(KVMIO, 0xf1)
 +#define KVM_VCPU_INJECT_SYSENTER _IO(KVMIO, 0xf2)
 +
-+/*
+ /*
   * Extension capability list.
   */
- #define KVM_CAP_IRQCHIP	  0
-Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
-===================================================================
---- 6.8.0-41-generic.orig/kernel/virt/kvm/kvm_main.c
-+++ 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
-@@ -501,6 +501,14 @@ static void kvm_vcpu_init(struct kvm_vcp
+diff --git a/virt/kvm/kvm_main.c b/virt/kvm/kvm_main.c
+index 10bfc88a69f7..9ff4cafabb14 100644
+--- a/virt/kvm/kvm_main.c
++++ b/virt/kvm/kvm_main.c
+@@ -501,6 +501,14 @@ static void kvm_vcpu_init(struct kvm_vcpu *vcpu, struct kvm *kvm, unsigned id)
  	/* Fill the stats id string for the vcpu */
  	snprintf(vcpu->stats_id, sizeof(vcpu->stats_id), "kvm-%d/vcpu-%d",
  		 task_pid_nr(current), id);
@@ -1423,7 +1587,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  }
  
  static void kvm_vcpu_destroy(struct kvm_vcpu *vcpu)
-@@ -1295,6 +1303,9 @@ static struct kvm *kvm_create_vm(unsigne
+@@ -1295,6 +1303,9 @@ static struct kvm *kvm_create_vm(unsigned long type, const char *fdname)
  	preempt_notifier_inc();
  	kvm_init_pm_notifier(kvm);
  
@@ -1433,7 +1597,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  	return kvm;
  
  out_err:
-@@ -1446,6 +1457,18 @@ static int kvm_vm_release(struct inode *
+@@ -1446,6 +1457,18 @@ static int kvm_vm_release(struct inode *inode, struct file *filp)
  	return 0;
  }
  
@@ -1452,7 +1616,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  /*
   * Allocation size is twice as large as the actual dirty bitmap size.
   * See kvm_vm_ioctl_get_dirty_log() why this is needed.
-@@ -3773,6 +3796,9 @@ bool kvm_vcpu_block(struct kvm_vcpu *vcp
+@@ -3773,6 +3796,9 @@ bool kvm_vcpu_block(struct kvm_vcpu *vcpu)
  		if (kvm_vcpu_check_block(vcpu) < 0)
  			break;
  
@@ -1462,7 +1626,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  		waited = true;
  		schedule();
  	}
-@@ -4162,16 +4188,81 @@ static int kvm_vcpu_release(struct inode
+@@ -4162,16 +4188,81 @@ static int kvm_vcpu_release(struct inode *inode, struct file *filp)
  {
  	struct kvm_vcpu *vcpu = filp->private_data;
  
@@ -1544,7 +1708,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  };
  
  /*
-@@ -4198,6 +4289,11 @@ static int vcpu_get_pid(void *data, u64
+@@ -4198,6 +4289,11 @@ static int vcpu_get_pid(void *data, u64 *val)
  
  DEFINE_SIMPLE_ATTRIBUTE(vcpu_get_pid_fops, vcpu_get_pid, NULL, "%llu\n");
  
@@ -1556,7 +1720,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  static void kvm_create_vcpu_debugfs(struct kvm_vcpu *vcpu)
  {
  	struct dentry *debugfs_dentry;
-@@ -4330,6 +4426,35 @@ vcpu_decrement:
+@@ -4330,6 +4426,35 @@ static int kvm_vm_ioctl_create_vcpu(struct kvm *kvm, u32 id)
  	return r;
  }
  
@@ -1592,7 +1756,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  static int kvm_vcpu_ioctl_set_sigmask(struct kvm_vcpu *vcpu, sigset_t *sigset)
  {
  	if (sigset) {
-@@ -4392,6 +4517,31 @@ static int kvm_vcpu_ioctl_get_stats_fd(s
+@@ -4392,6 +4517,31 @@ static int kvm_vcpu_ioctl_get_stats_fd(struct kvm_vcpu *vcpu)
  	return fd;
  }
  
@@ -1624,7 +1788,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  static long kvm_vcpu_ioctl(struct file *filp,
  			   unsigned int ioctl, unsigned long arg)
  {
-@@ -4401,8 +4551,8 @@ static long kvm_vcpu_ioctl(struct file *
+@@ -4401,8 +4551,8 @@ static long kvm_vcpu_ioctl(struct file *filp,
  	struct kvm_fpu *fpu = NULL;
  	struct kvm_sregs *kvm_sregs = NULL;
  
@@ -1635,7 +1799,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  
  	if (unlikely(_IOC_TYPE(ioctl) != KVMIO))
  		return -EINVAL;
-@@ -4415,6 +4565,69 @@ static long kvm_vcpu_ioctl(struct file *
+@@ -4415,6 +4565,69 @@ static long kvm_vcpu_ioctl(struct file *filp,
  	if (r != -ENOIOCTLCMD)
  		return r;
  
@@ -1705,7 +1869,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  	if (mutex_lock_killable(&vcpu->mutex))
  		return -EINTR;
  	switch (ioctl) {
-@@ -5096,8 +5309,8 @@ static long kvm_vm_ioctl(struct file *fi
+@@ -5096,8 +5309,8 @@ static long kvm_vm_ioctl(struct file *filp,
  	void __user *argp = (void __user *)arg;
  	int r;
  
@@ -1716,7 +1880,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  	switch (ioctl) {
  	case KVM_CREATE_VCPU:
  		r = kvm_vm_ioctl_create_vcpu(kvm, arg);
-@@ -5321,6 +5534,9 @@ static long kvm_vm_ioctl(struct file *fi
+@@ -5321,6 +5534,9 @@ static long kvm_vm_ioctl(struct file *filp,
  		break;
  	}
  #endif
@@ -1726,7 +1890,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  	default:
  		r = kvm_arch_vm_ioctl(filp, ioctl, arg);
  	}
-@@ -5408,11 +5624,99 @@ static long kvm_vm_compat_ioctl(struct f
+@@ -5408,11 +5624,99 @@ static long kvm_vm_compat_ioctl(struct file *filp,
  }
  #endif
  
@@ -1826,7 +1990,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  };
  
  bool file_is_kvm(struct file *file)
-@@ -5464,10 +5768,39 @@ put_fd:
+@@ -5464,10 +5768,39 @@ static int kvm_dev_ioctl_create_vm(unsigned long type)
  	return r;
  }
  
@@ -1866,7 +2030,7 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  
  	switch (ioctl) {
  	case KVM_GET_API_VERSION:
-@@ -5492,6 +5825,48 @@ static long kvm_dev_ioctl(struct file *f
+@@ -5492,6 +5825,48 @@ static long kvm_dev_ioctl(struct file *filp,
  		r += PAGE_SIZE;    /* coalesced mmio ring page */
  #endif
  		break;
@@ -1915,177 +2079,3 @@ Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
  	default:
  		return kvm_arch_dev_ioctl(filp, ioctl, arg);
  	}
-Index: 6.8.0-41-generic/kernel/arch/x86/kvm/mmu/mmu.c
-===================================================================
---- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/mmu/mmu.c
-+++ 6.8.0-41-generic/kernel/arch/x86/kvm/mmu/mmu.c
-@@ -4596,6 +4596,37 @@ int kvm_tdp_page_fault(struct kvm_vcpu *
- 		}
- 	}
- 
-+	/* If IntroVirt is hooking EPT faults, deliver here */
-+	if (fault->guest_initiated && kvm_is_mem_event_enabled(vcpu->kvm))
-+	{
-+		/* Look up the fault */
-+		struct kvm *kvm = vcpu->kvm;
-+		struct mem_access_entry *entry;
-+		const u64 gfn = fault->gfn;
-+		bool found_match = false;
-+
-+		mutex_lock(&kvm->mem_access_table.mutex);
-+
-+		/* Search for the entry */
-+		hash_for_each_possible(kvm->mem_access_table.table, entry, node, gfn)
-+		{
-+			/* Found a match, check requested permission */
-+			if(entry->gfn == gfn) {
-+				/* Match! */
-+				found_match = true;
-+				break;
-+			}
-+		}
-+		mutex_unlock(&kvm->mem_access_table.mutex);
-+
-+		/* If we found a match, deliver it */
-+		if (found_match) {
-+			printk(KERN_DEBUG "IV-mmu: Matched EPT fault mem event for gfn 0x%08llx. Code: %d\n", gfn, fault->error_code);
-+			kvm_deliver_mem_event(vcpu, fault->addr, fault->error_code);
-+			return RET_PF_RETRY;
-+		}
-+	}
-+
- #ifdef CONFIG_X86_64
- 	if (tdp_mmu_enabled)
- 		return kvm_tdp_mmu_page_fault(vcpu, fault);
-@@ -4604,6 +4635,71 @@ int kvm_tdp_page_fault(struct kvm_vcpu *
- 	return direct_page_fault(vcpu, fault);
- }
- 
-+static int kvm_tdp_set_pte_perms(struct kvm_vcpu *vcpu, u64 gfn, uint8_t perms, uint8_t* original_perms)
-+{
-+	struct kvm_shadow_walk_iterator iterator;
-+	int result = -ESRCH;
-+	u64 gpa = gfn << PAGE_SHIFT;
-+	u64 spte = 0ull;
-+
-+	// Turn off any extra bits in the perms
-+	perms &= (PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK);
-+
-+	// Validate the HAP permissions are allowed
-+	if (unlikely(!kvm_x86_ops.hap_permissions_allowed(perms)))
-+		return -EINVAL;
-+
-+	if (!VALID_PAGE(vcpu->arch.mmu->root.hpa))
-+	{
-+		result = kvm_mmu_load(vcpu);
-+		if (unlikely(result))
-+			return result;
-+	}
-+
-+retry:
-+	walk_shadow_page_lockless_begin(vcpu);
-+
-+	/* Find the page in the shadow tables */
-+	for_each_shadow_entry_lockless(vcpu, gpa, iterator, spte)
-+		if (!is_shadow_present_pte(spte) ||
-+			iterator.level < PG_LEVEL_4K)
-+				{
-+					/* The page is not present, so page it in for the guest process */
-+					struct mm_struct* mm;
-+					int r;
-+
-+					walk_shadow_page_lockless_end(vcpu);
-+
-+					/* Dirty hack */
-+					/* hva_to_pfn() is hard-coded to current->mm */
-+					mm = current->mm;
-+					current->mm = vcpu->kvm->mm;
-+					r = __kvm_mmu_do_page_fault(vcpu, gpa, 0, false, NULL, false);
-+					current->mm = mm;
-+					if (r)
-+						return r;
-+					goto retry;
-+				}
-+
-+	// Try a few times to update the pte
-+	result = -EBUSY;
-+	do {
-+		u64 new_spte = (spte & ~(PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK)) | perms;
-+
-+		if (original_perms != NULL)
-+			*original_perms = (spte & (PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK));
-+
-+		if (cmpxchg64(iterator.sptep, spte, new_spte) == spte)
-+		{
-+			result = 0;
-+			break;
-+		}
-+	} while(true);
-+
-+	walk_shadow_page_lockless_end(vcpu);
-+	return result;
-+}
-+
- static void nonpaging_init_context(struct kvm_mmu *context)
- {
- 	context->page_fault = nonpaging_page_fault;
-@@ -5299,6 +5395,7 @@ static void init_kvm_tdp_mmu(struct kvm_
- 	context->cpu_role.as_u64 = cpu_role.as_u64;
- 	context->root_role.word = root_role.word;
- 	context->page_fault = kvm_tdp_page_fault;
-+	context->set_pte_perms = kvm_tdp_set_pte_perms;
- 	context->sync_spte = NULL;
- 	context->get_guest_pgd = get_guest_cr3;
- 	context->get_pdptr = kvm_pdptr_read;
-Index: 6.8.0-41-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
-===================================================================
---- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/mmu/mmu_internal.h
-+++ 6.8.0-41-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
-@@ -247,6 +247,11 @@ struct kvm_page_fault {
- 	 * is changing its own translation in the guest page tables.
- 	 */
- 	bool write_fault_to_shadow_pgtable;
-+
-+	/*
-+	 * IntroVirt Patch
-+	 */
-+	bool guest_initiated;
- };
- 
- int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault);
-@@ -279,8 +284,8 @@ enum {
- 	RET_PF_SPURIOUS,
- };
- 
--static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
--					u32 err, bool prefetch, int *emulation_type)
-+static inline int __kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
-+					u32 err, bool prefetch, int *emulation_type, bool guest_initiated)
- {
- 	struct kvm_page_fault fault = {
- 		.addr = cr2_or_gpa,
-@@ -299,6 +304,11 @@ static inline int kvm_mmu_do_page_fault(
- 		.req_level = PG_LEVEL_4K,
- 		.goal_level = PG_LEVEL_4K,
- 		.is_private = kvm_mem_is_private(vcpu->kvm, cr2_or_gpa >> PAGE_SHIFT),
-+
-+		/*
-+		 * IntroVirt Patch
-+		 */
-+		.guest_initiated = guest_initiated,
- 	};
- 	int r;
- 
-@@ -339,6 +349,12 @@ static inline int kvm_mmu_do_page_fault(
- 	return r;
- }
- 
-+static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
-+					u32 err, bool prefetch, int *emulation_type)
-+{
-+	return __kvm_mmu_do_page_fault(vcpu, cr2_or_gpa, err, prefetch, emulation_type, 1);
-+}
-+
- int kvm_mmu_max_mapping_level(struct kvm *kvm,
- 			      const struct kvm_memory_slot *slot, gfn_t gfn,
- 			      int max_level);

--- a/ubuntu/noble/hwe/6.8.0-41-generic/patches/kvm-introvirt-hwe-6.8.0-41-generic
+++ b/ubuntu/noble/hwe/6.8.0-41-generic/patches/kvm-introvirt-hwe-6.8.0-41-generic
@@ -8,10 +8,10 @@ Bug: https://github.com/IntroVirt/kvm-introvirt/issues
 Last-Update: 2024-09-03
 ---
 This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
-Index: 6.8.0-40-generic/kernel/arch/x86/include/asm/kvm_host.h
+Index: 6.8.0-41-generic/kernel/arch/x86/include/asm/kvm_host.h
 ===================================================================
---- 6.8.0-40-generic.orig/kernel/arch/x86/include/asm/kvm_host.h
-+++ 6.8.0-40-generic/kernel/arch/x86/include/asm/kvm_host.h
+--- 6.8.0-41-generic.orig/kernel/arch/x86/include/asm/kvm_host.h
++++ 6.8.0-41-generic/kernel/arch/x86/include/asm/kvm_host.h
 @@ -454,6 +454,7 @@ struct kvm_mmu {
  			    struct x86_exception *exception);
  	int (*sync_spte)(struct kvm_vcpu *vcpu,
@@ -22,7 +22,7 @@ Index: 6.8.0-40-generic/kernel/arch/x86/include/asm/kvm_host.h
  	union kvm_mmu_page_role root_role;
 @@ -1797,6 +1798,13 @@ struct kvm_x86_ops {
  	unsigned long (*vcpu_get_apicv_inhibit_reasons)(struct kvm_vcpu *vcpu);
- 
+
  	gva_t (*get_untagged_addr)(struct kvm_vcpu *vcpu, gva_t gva, unsigned int flags);
 +
 +	/* IntroVirt patch */
@@ -32,16 +32,16 @@ Index: 6.8.0-40-generic/kernel/arch/x86/include/asm/kvm_host.h
 +	bool (*hap_permissions_allowed)(uint16_t perms);
 +	void (*update_syscall_intercept)(struct kvm_vcpu *vcpu);
  };
- 
+
  struct kvm_x86_nested_ops {
-Index: 6.8.0-40-generic/kernel/arch/x86/kvm/emulate.c
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/emulate.c
 ===================================================================
---- 6.8.0-40-generic.orig/kernel/arch/x86/kvm/emulate.c
-+++ 6.8.0-40-generic/kernel/arch/x86/kvm/emulate.c
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/emulate.c
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/emulate.c
 @@ -2455,6 +2455,69 @@ static int em_syscall(struct x86_emulate
  	return X86EMUL_CONTINUE;
  }
- 
+
 +static int em_sysret(struct x86_emulate_ctxt *ctxt)
 +{
 +	const struct x86_emulate_ops *ops = ctxt->ops;
@@ -117,10 +117,10 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/emulate.c
  	DI(ImplicitOps | Priv, invd), DI(ImplicitOps | Priv, wbinvd), N, N,
  	N, D(ImplicitOps | ModRM | SrcMem | NoAccess), N, N,
  	/* 0x10 - 0x1F */
-Index: 6.8.0-40-generic/kernel/arch/x86/kvm/irq.c
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/irq.c
 ===================================================================
---- 6.8.0-40-generic.orig/kernel/arch/x86/kvm/irq.c
-+++ 6.8.0-40-generic/kernel/arch/x86/kvm/irq.c
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/irq.c
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/irq.c
 @@ -58,6 +58,9 @@ int kvm_cpu_has_extint(struct kvm_vcpu *
  	 * pending interrupt or should re-inject an injected
  	 * interrupt.
@@ -130,11 +130,11 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/irq.c
 +
  	if (!lapic_in_kernel(v))
  		return v->arch.interrupt.injected;
- 
-Index: 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/capabilities.h
+
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/capabilities.h
 ===================================================================
---- 6.8.0-40-generic.orig/kernel/arch/x86/kvm/vmx/capabilities.h
-+++ 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/capabilities.h
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/vmx/capabilities.h
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/capabilities.h
 @@ -71,6 +71,7 @@ extern struct vmcs_config vmcs_config __
  struct vmx_capability {
  	u32 ept;
@@ -142,11 +142,11 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/capabilities.h
 +	bool mtf;
  };
  extern struct vmx_capability vmx_capability __ro_after_init;
- 
+
 @@ -116,6 +117,11 @@ static inline bool cpu_has_vmx_tpr_shado
  	return vmcs_config.cpu_based_exec_ctrl & CPU_BASED_TPR_SHADOW;
  }
- 
+
 +static inline bool cpu_has_monitor_trap_flag(void)
 +{
 +	return vmx_capability.mtf;
@@ -155,10 +155,10 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/capabilities.h
  static inline bool cpu_need_tpr_shadow(struct kvm_vcpu *vcpu)
  {
  	return cpu_has_vmx_tpr_shadow() && lapic_in_kernel(vcpu);
-Index: 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/vmx.c
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
 ===================================================================
---- 6.8.0-40-generic.orig/kernel/arch/x86/kvm/vmx/vmx.c
-+++ 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/vmx.c
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/vmx/vmx.c
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
 @@ -883,7 +883,7 @@ void vmx_update_exception_bitmap(struct
  	 * We intercept those #GP and allow access to them anyway
  	 * as VMware does.
@@ -171,7 +171,7 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/vmx.c
 @@ -1116,6 +1116,11 @@ static bool update_transition_efer(struc
  		ignore_bits &= ~(u64)EFER_SCE;
  #endif
- 
+
 +	/* IntroVirt patch to intercept system calls */
 +	if (vmx->vcpu.syscall_hook_enabled) {
 +		guest_efer &= ~EFER_SCE;
@@ -193,7 +193,7 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/vmx.c
 @@ -2624,6 +2630,13 @@ static int setup_vmcs_config(struct vmcs
  				SECONDARY_EXEC_VIRTUALIZE_X2APIC_MODE |
  				SECONDARY_EXEC_VIRTUAL_INTR_DELIVERY);
- 
+
 +	if (_cpu_based_exec_control & CPU_BASED_MONITOR_TRAP_FLAG) {
 +		_cpu_based_exec_control &= ~CPU_BASED_MONITOR_TRAP_FLAG;
 +		vmx_cap->mtf = true;
@@ -203,14 +203,14 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/vmx.c
 +
  	rdmsr_safe(MSR_IA32_VMX_EPT_VPID_CAP,
  		&vmx_cap->ept, &vmx_cap->vpid);
- 
+
 @@ -5218,7 +5231,7 @@ static int handle_exception_nmi(struct k
  		error_code = vmcs_read32(VM_EXIT_INTR_ERROR_CODE);
- 
+
  	if (!vmx->rmode.vm86_active && is_gp_fault(intr_info)) {
 -		WARN_ON_ONCE(!enable_vmware_backdoor);
 +		/* WARN_ON_ONCE(!enable_vmware_backdoor); */
- 
+
  		/*
  		 * VMware backdoor emulation on #GP interception only handles
 @@ -5320,6 +5333,24 @@ static int handle_exception_nmi(struct k
@@ -281,7 +281,7 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/vmx.c
  		}
  		break;
 @@ -5941,6 +5980,11 @@ static int handle_pause(struct kvm_vcpu
- 
+
  static int handle_monitor_trap(struct kvm_vcpu *vcpu)
  {
 +	/*
@@ -291,7 +291,7 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/vmx.c
 +		kvm_deliver_monitor_trap_flag_event(vcpu);
  	return 1;
  }
- 
+
 @@ -7514,7 +7558,8 @@ static int vmx_vcpu_create(struct kvm_vc
  	vmx_disable_intercept_for_msr(vcpu, MSR_GS_BASE, MSR_TYPE_RW);
  	vmx_disable_intercept_for_msr(vcpu, MSR_KERNEL_GS_BASE, MSR_TYPE_RW);
@@ -305,7 +305,7 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/vmx.c
 @@ -8284,6 +8329,102 @@ gva_t vmx_get_untagged_addr(struct kvm_v
  	return (sign_extend64(gva, lam_bit) & ~BIT_ULL(63)) | (gva & BIT_ULL(63));
  }
- 
+
 +static int vmx_set_cr_monitor(struct kvm_vcpu *vcpu, int cr, int mode)
 +{
 +	struct vcpu_vmx *vmx = to_vmx(vcpu);
@@ -404,10 +404,10 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/vmx.c
 +
  static struct kvm_x86_ops vmx_x86_ops __initdata = {
  	.name = KBUILD_MODNAME,
- 
+
 @@ -8426,6 +8567,13 @@ static struct kvm_x86_ops vmx_x86_ops __
  	.vcpu_deliver_sipi_vector = kvm_vcpu_deliver_sipi_vector,
- 
+
  	.get_untagged_addr = vmx_get_untagged_addr,
 +
 +	/* IntroVirt patch */
@@ -417,16 +417,16 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/vmx/vmx.c
 +	.set_invlpg_monitor = vmx_set_invlpg_monitor,
 +	.hap_permissions_allowed = vmx_hap_permissions_allowed,
  };
- 
+
  static unsigned int vmx_handle_intel_pt_intr(void)
-Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.c
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
 ===================================================================
---- 6.8.0-40-generic.orig/kernel/arch/x86/kvm/x86.c
-+++ 6.8.0-40-generic/kernel/arch/x86/kvm/x86.c
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/x86.c
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
 @@ -129,6 +129,11 @@ static void store_regs(struct kvm_vcpu *
  static int sync_regs(struct kvm_vcpu *vcpu);
  static int kvm_vcpu_do_singlestep(struct kvm_vcpu *vcpu);
- 
+
 +/* IntroVirt introspection patch */
 +void kvm_arch_clear_mem_access(struct kvm* kvm);
 +static void init_emulate_ctxt(struct kvm_vcpu *vcpu);
@@ -434,7 +434,7 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.c
 +
  static int __set_sregs2(struct kvm_vcpu *vcpu, struct kvm_sregs2 *sregs2);
  static void __get_sregs2(struct kvm_vcpu *vcpu, struct kvm_sregs2 *sregs2);
- 
+
 @@ -1872,6 +1877,15 @@ static int __kvm_set_msr(struct kvm_vcpu
  		 */
  		data = __canonical_address(data, vcpu_virt_addr_bits(vcpu));
@@ -464,7 +464,7 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.c
 @@ -5804,6 +5821,26 @@ static int kvm_vcpu_ioctl_enable_cap(str
  	}
  }
- 
+
 +static int kvm_set_syscall_hook(struct kvm_vcpu *vcpu, bool enabled)
 +{
 +	int rc = 0;
@@ -695,13 +695,13 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.c
  	bool writeback = true;
 +	bool sysret = false;
 +	bool sysexit = false;
- 
+
  	r = kvm_check_emulate_insn(vcpu, emulation_type, insn, insn_len);
  	if (r != X86EMUL_CONTINUE) {
 @@ -9127,10 +9353,54 @@ int x86_emulate_instruction(struct kvm_v
  		}
  	}
- 
+
 -	if ((emulation_type & EMULTYPE_VMWARE_GP) &&
 -	    !is_vmware_backdoor_opcode(ctxt)) {
 -		kvm_queue_exception_e(vcpu, GP_VECTOR, 0);
@@ -755,12 +755,12 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.c
 +			return 1;
 +		}
  	}
- 
+
  	/*
 @@ -9256,6 +9526,11 @@ writeback:
  	} else
  		vcpu->arch.emulate_regs_need_sync_to_vcpu = true;
- 
+
 +	if (sysret)
 +		kvm_deliver_sysret_event(vcpu);
 +	else if (sysexit)
@@ -768,11 +768,11 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.c
 +
  	return r;
  }
- 
+
 @@ -9829,6 +10104,46 @@ void kvm_x86_vendor_exit(void)
  }
  EXPORT_SYMBOL_GPL(kvm_x86_vendor_exit);
- 
+
 +void kvm_arch_clear_mem_access(struct kvm* kvm) {
 +	unsigned long i;
 +	struct kvm_vcpu * vcpu = NULL;
@@ -819,7 +819,7 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.c
 @@ -10021,13 +10336,26 @@ int kvm_emulate_hypercall(struct kvm_vcp
  	unsigned long nr, a0, a1, a2, a3, ret;
  	int op_64_bit;
- 
+
 +	nr = kvm_rax_read(vcpu);
 +	if(nr == 0xFACE)
 +	{
@@ -835,10 +835,10 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.c
 +
  	if (kvm_xen_hypercall_enabled(vcpu->kvm))
  		return kvm_xen_hypercall(vcpu);
- 
+
  	if (kvm_hv_hypercall_enabled(vcpu))
  		return kvm_hv_hypercall(vcpu);
- 
+
 -	nr = kvm_rax_read(vcpu);
 +	/*nr = kvm_rax_read(vcpu);*/
  	a0 = kvm_rbx_read(vcpu);
@@ -847,7 +847,7 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.c
 @@ -11186,6 +11514,26 @@ static int vcpu_run(struct kvm_vcpu *vcp
  			r = vcpu_block(vcpu);
  		}
- 
+
 +		/*
 +		 * We shouldn't get here during an event
 +		 * The vcpu will be blocked in event delivery
@@ -870,11 +870,11 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.c
 +
  		if (r <= 0)
  			break;
- 
+
 @@ -11741,6 +12089,12 @@ static int __set_sregs_common(struct kvm
  	*mmu_reset_needed |= kvm_read_cr0(vcpu) != sregs->cr0;
  	static_call(kvm_x86_set_cr0)(vcpu, sregs->cr0);
- 
+
 +	if (kvm_rip_read(vcpu) == 0xfff0) {
 +		vcpu->reboot_pending = true;
 +	} else {
@@ -883,11 +883,11 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.c
 +
  	*mmu_reset_needed |= kvm_read_cr4(vcpu) != sregs->cr4;
  	static_call(kvm_x86_set_cr4)(vcpu, sregs->cr4);
- 
+
 @@ -13555,6 +13909,206 @@ int kvm_spec_ctrl_test_value(u64 value)
  }
  EXPORT_SYMBOL_GPL(kvm_spec_ctrl_test_value);
- 
+
 +static void kvm_deliver_introspection_event(struct kvm_vcpu* vcpu,
 +		struct kvm_introspection_event* event)
 +{
@@ -1091,14 +1091,14 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.c
  void kvm_fixup_and_inject_pf_error(struct kvm_vcpu *vcpu, gva_t gva, u16 error_code)
  {
  	struct kvm_mmu *mmu = vcpu->arch.walk_mmu;
-Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.h
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.h
 ===================================================================
---- 6.8.0-40-generic.orig/kernel/arch/x86/kvm/x86.h
-+++ 6.8.0-40-generic/kernel/arch/x86/kvm/x86.h
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/x86.h
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/x86.h
 @@ -322,6 +322,29 @@ int x86_emulate_instruction(struct kvm_v
  			    int emulation_type, void *insn, int insn_len);
  fastpath_t handle_fastpath_set_msr_irqoff(struct kvm_vcpu *vcpu);
- 
+
 +static inline int kvm_is_cr_hooked(struct kvm_vcpu *vcpu, int cr, int mode)
 +{
 +	return (((vcpu->cr_monitor_mask) >> (cr * 2)) & mode) != 0;
@@ -1125,10 +1125,10 @@ Index: 6.8.0-40-generic/kernel/arch/x86/kvm/x86.h
  extern u64 host_xcr0;
  extern u64 host_xss;
  extern u64 host_arch_capabilities;
-Index: 6.8.0-40-generic/kernel/include/linux/kvm_host.h
+Index: 6.8.0-41-generic/kernel/include/linux/kvm_host.h
 ===================================================================
---- 6.8.0-40-generic.orig/kernel/include/linux/kvm_host.h
-+++ 6.8.0-40-generic/kernel/include/linux/kvm_host.h
+--- 6.8.0-41-generic.orig/kernel/include/linux/kvm_host.h
++++ 6.8.0-41-generic/kernel/include/linux/kvm_host.h
 @@ -28,6 +28,7 @@
  #include <linux/rcuwait.h>
  #include <linux/refcount.h>
@@ -1167,7 +1167,7 @@ Index: 6.8.0-40-generic/kernel/include/linux/kvm_host.h
 @@ -730,6 +751,17 @@ struct kvm_memslots {
  	int node_idx;
  };
- 
+
 +struct mem_access_entry {
 +	struct hlist_node node;
 +	u64 gfn;
@@ -1193,12 +1193,12 @@ Index: 6.8.0-40-generic/kernel/include/linux/kvm_host.h
 +	struct mm_struct *introspection_mm;
 +	bool mem_event_enabled;
  };
- 
+
  #define kvm_err(fmt, ...) \
 @@ -985,6 +1023,9 @@ void kvm_destroy_vcpus(struct kvm *kvm);
  void vcpu_load(struct kvm_vcpu *vcpu);
  void vcpu_put(struct kvm_vcpu *vcpu);
- 
+
 +void kvm_vcpu_pause(struct kvm_vcpu *vcpu);
 +void kvm_vcpu_unpause(struct kvm_vcpu *vcpu);
 +
@@ -1214,17 +1214,17 @@ Index: 6.8.0-40-generic/kernel/include/linux/kvm_host.h
  int kvm_vcpu_yield_to(struct kvm_vcpu *target);
  void kvm_vcpu_on_spin(struct kvm_vcpu *vcpu, bool yield_to_kernel_mode);
 +void kvm_vcpu_check_pause(struct kvm_vcpu *vcpu); /* IntroVirt addition */
- 
+
  void kvm_flush_remote_tlbs(struct kvm *kvm);
  void kvm_flush_remote_tlbs_range(struct kvm *kvm, gfn_t gfn, u64 nr_pages);
-Index: 6.8.0-40-generic/kernel/include/uapi/linux/kvm.h
+Index: 6.8.0-41-generic/kernel/include/uapi/linux/kvm.h
 ===================================================================
---- 6.8.0-40-generic.orig/kernel/include/uapi/linux/kvm.h
-+++ 6.8.0-40-generic/kernel/include/uapi/linux/kvm.h
+--- 6.8.0-41-generic.orig/kernel/include/uapi/linux/kvm.h
++++ 6.8.0-41-generic/kernel/include/uapi/linux/kvm.h
 @@ -536,6 +536,20 @@ struct kvm_translation {
  	__u8  pad[5];
  };
- 
+
 +/* for KVM_TRANSLATE_DTB */
 +struct kvm_translation_dtb {
 +	/* in */
@@ -1244,7 +1244,7 @@ Index: 6.8.0-40-generic/kernel/include/uapi/linux/kvm.h
  	/* in */
 @@ -901,6 +915,133 @@ struct kvm_ppc_resize_hpt {
  #define KVM_GET_MSR_FEATURE_INDEX_LIST    _IOWR(KVMIO, 0x0a, struct kvm_msr_list)
- 
+
  /*
 + * Introspection API (KVM_CAP_INTROSPECTION)
 + */
@@ -1376,10 +1376,10 @@ Index: 6.8.0-40-generic/kernel/include/uapi/linux/kvm.h
   * Extension capability list.
   */
  #define KVM_CAP_IRQCHIP	  0
-Index: 6.8.0-40-generic/kernel/virt/kvm/kvm_main.c
+Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
 ===================================================================
---- 6.8.0-40-generic.orig/kernel/virt/kvm/kvm_main.c
-+++ 6.8.0-40-generic/kernel/virt/kvm/kvm_main.c
+--- 6.8.0-41-generic.orig/kernel/virt/kvm/kvm_main.c
++++ 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
 @@ -501,6 +501,14 @@ static void kvm_vcpu_init(struct kvm_vcp
  	/* Fill the stats id string for the vcpu */
  	snprintf(vcpu->stats_id, sizeof(vcpu->stats_id), "kvm-%d/vcpu-%d",
@@ -1393,22 +1393,22 @@ Index: 6.8.0-40-generic/kernel/virt/kvm/kvm_main.c
 +	vcpu->introspection_event = NULL;
 +	vcpu->reboot_pending = false;
  }
- 
+
  static void kvm_vcpu_destroy(struct kvm_vcpu *vcpu)
 @@ -1295,6 +1303,9 @@ static struct kvm *kvm_create_vm(unsigne
  	preempt_notifier_inc();
  	kvm_init_pm_notifier(kvm);
- 
+
 +	mutex_init(&kvm->mem_access_table.mutex);
 +	hash_init(kvm->mem_access_table.table);
 +
  	return kvm;
- 
+
  out_err:
 @@ -1446,6 +1457,18 @@ static int kvm_vm_release(struct inode *
  	return 0;
  }
- 
+
 +static int kvm_vm_introvirt_release(struct inode *inode, struct file *filp)
 +{
 +    struct kvm *kvm = filp->private_data;
@@ -1427,7 +1427,7 @@ Index: 6.8.0-40-generic/kernel/virt/kvm/kvm_main.c
 @@ -3779,6 +3802,9 @@ bool kvm_vcpu_block(struct kvm_vcpu *vcp
  		if (kvm_vcpu_check_block(vcpu) < 0)
  			break;
- 
+
 +		if (unlikely(atomic_read(&vcpu->pause_count) > 0))
 +			break;
 +
@@ -1437,14 +1437,14 @@ Index: 6.8.0-40-generic/kernel/virt/kvm/kvm_main.c
 @@ -4168,16 +4194,81 @@ static int kvm_vcpu_release(struct inode
  {
  	struct kvm_vcpu *vcpu = filp->private_data;
- 
+
 +	if (vcpu->vcpu_id == 0)
 +		kvm_deliver_shutdown_event(vcpu);
 +
  	kvm_put_kvm(vcpu->kvm);
  	return 0;
  }
- 
+
 +
 +static int kvm_vcpu_introvirt_release(struct inode *inode, struct file *filp)
 +{
@@ -1514,12 +1514,12 @@ Index: 6.8.0-40-generic/kernel/virt/kvm/kvm_main.c
 +    KVM_COMPAT(kvm_vcpu_compat_ioctl),
 +    .poll       = kvm_vcpu_poll,
  };
- 
+
  /*
 @@ -4204,6 +4295,11 @@ static int vcpu_get_pid(void *data, u64
- 
+
  DEFINE_SIMPLE_ATTRIBUTE(vcpu_get_pid_fops, vcpu_get_pid, NULL, "%llu\n");
- 
+
 +static int create_vcpu_introvirt_fd(struct kvm_vcpu *vcpu)
 +{
 +    return anon_inode_getfd("kvm-vcpu", &kvm_vcpu_introvirt_fops, vcpu, O_RDWR | O_CLOEXEC);
@@ -1531,7 +1531,7 @@ Index: 6.8.0-40-generic/kernel/virt/kvm/kvm_main.c
 @@ -4336,6 +4432,35 @@ vcpu_decrement:
  	return r;
  }
- 
+
 +/* Attach for introspection */
 +static int kvm_vm_ioctl_attach_vcpu(struct kvm *kvm, u32 id) {
 +	struct kvm_vcpu* vcpu;
@@ -1567,7 +1567,7 @@ Index: 6.8.0-40-generic/kernel/virt/kvm/kvm_main.c
 @@ -4398,6 +4523,31 @@ static int kvm_vcpu_ioctl_get_stats_fd(s
  	return fd;
  }
- 
+
 +void kvm_vcpu_pause(struct kvm_vcpu *vcpu)
 +{
 +	if (atomic_inc_return(&vcpu->pause_count) == 1) {
@@ -1599,18 +1599,18 @@ Index: 6.8.0-40-generic/kernel/virt/kvm/kvm_main.c
 @@ -4407,8 +4557,8 @@ static long kvm_vcpu_ioctl(struct file *
  	struct kvm_fpu *fpu = NULL;
  	struct kvm_sregs *kvm_sregs = NULL;
- 
+
 -	if (vcpu->kvm->mm != current->mm || vcpu->kvm->vm_dead)
 -		return -EIO;
 +	/*if (vcpu->kvm->mm != current->mm || vcpu->kvm->vm_dead)
 +		return -EIO;*/
- 
+
  	if (unlikely(_IOC_TYPE(ioctl) != KVMIO))
  		return -EINVAL;
 @@ -4421,6 +4571,69 @@ static long kvm_vcpu_ioctl(struct file *
  	if (r != -ENOIOCTLCMD)
  		return r;
- 
+
 +	// IOCTLs that take place without locking vcpu->mutex
 +	switch (ioctl) {
 +	case KVM_VCPU_PAUSE: {
@@ -1680,7 +1680,7 @@ Index: 6.8.0-40-generic/kernel/virt/kvm/kvm_main.c
 @@ -5102,8 +5315,8 @@ static long kvm_vm_ioctl(struct file *fi
  	void __user *argp = (void __user *)arg;
  	int r;
- 
+
 -	if (kvm->mm != current->mm || kvm->vm_dead)
 -		return -EIO;
 +	/*if (kvm->mm != current->mm || kvm->vm_dead)
@@ -1701,7 +1701,7 @@ Index: 6.8.0-40-generic/kernel/virt/kvm/kvm_main.c
 @@ -5414,11 +5630,99 @@ static long kvm_vm_compat_ioctl(struct f
  }
  #endif
- 
+
 +static void kvm_vm_munmap(struct vm_area_struct *vma) {
 +	struct page* page = vma->vm_private_data;
 +	put_page(page);
@@ -1796,12 +1796,12 @@ Index: 6.8.0-40-generic/kernel/virt/kvm/kvm_main.c
 +    .llseek     = noop_llseek,
 +    .mmap           = kvm_vm_mmap,
  };
- 
+
  bool file_is_kvm(struct file *file)
 @@ -5470,10 +5774,39 @@ put_fd:
  	return r;
  }
- 
+
 +/*
 + * Find a VM based on the PID
 + */
@@ -1835,7 +1835,7 @@ Index: 6.8.0-40-generic/kernel/virt/kvm/kvm_main.c
  {
  	int r = -EINVAL;
 +	void __user *argp = (void __user *)arg;
- 
+
  	switch (ioctl) {
  	case KVM_GET_API_VERSION:
 @@ -5498,6 +5831,48 @@ static long kvm_dev_ioctl(struct file *f

--- a/ubuntu/noble/hwe/6.8.0-90-generic/patches/kvm-introvirt-hwe-6.8.0-90-generic
+++ b/ubuntu/noble/hwe/6.8.0-90-generic/patches/kvm-introvirt-hwe-6.8.0-90-generic
@@ -1,0 +1,2091 @@
+Description: KVM IntroVirt patch for Ubuntu HWE kernel 6.8.0-90-generic
+ The KVM IntroVirt patch adds introspection support to KVM. This allows
+ for inspection of virtual machine memory and manipulation of running processes in-guest.
+ This patch is required for compatibility with the user-land IntroVirt library.
+Author: AIS Inc., introvirt@ainfosec.com
+Origin: upstream, https://github.com/IntroVirt/kvm-introvirt
+Bug: https://github.com/IntroVirt/kvm-introvirt/issues
+Last-Update: 2026-01-28
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+Index: 6.8.0-41-generic/kernel/arch/x86/include/asm/kvm_host.h
+===================================================================
+--- 6.8.0-41-generic.orig/kernel/arch/x86/include/asm/kvm_host.h
++++ 6.8.0-41-generic/kernel/arch/x86/include/asm/kvm_host.h
+@@ -454,6 +454,7 @@ struct kvm_mmu {
+ 			    struct x86_exception *exception);
+ 	int (*sync_spte)(struct kvm_vcpu *vcpu,
+ 			 struct kvm_mmu_page *sp, int i);
++	int (*set_pte_perms)(struct kvm_vcpu *vcpu, u64 gpa, uint8_t perms, uint8_t* original_perms);
+ 	struct kvm_mmu_root_info root;
+ 	union kvm_cpu_role cpu_role;
+ 	union kvm_mmu_page_role root_role;
+@@ -1794,6 +1795,13 @@ struct kvm_x86_ops {
+ 	unsigned long (*vcpu_get_apicv_inhibit_reasons)(struct kvm_vcpu *vcpu);
+ 
+ 	gva_t (*get_untagged_addr)(struct kvm_vcpu *vcpu, gva_t gva, unsigned int flags);
++
++	/* IntroVirt patch */
++	int (*set_cr_monitor)(struct kvm_vcpu *vcpu, int cr, int mode);
++	int (*set_monitor_trap_flag)(struct kvm_vcpu *vcpu, bool enabled);
++	int (*set_invlpg_monitor)(struct kvm_vcpu *vcpu, bool enabled);
++	bool (*hap_permissions_allowed)(uint16_t perms);
++	void (*update_syscall_intercept)(struct kvm_vcpu *vcpu);
+ };
+ 
+ struct kvm_x86_nested_ops {
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/emulate.c
+===================================================================
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/emulate.c
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/emulate.c
+@@ -2455,6 +2455,69 @@ static int em_syscall(struct x86_emulate
+ 	return X86EMUL_CONTINUE;
+ }
+ 
++static int em_sysret(struct x86_emulate_ctxt *ctxt)
++{
++	const struct x86_emulate_ops *ops = ctxt->ops;
++	struct desc_struct cs, ss;
++	u64 msr_data, rcx;
++	u16 cs_sel, ss_sel;
++	u64 efer = 0;
++
++	/* syscall is not available in real mode */
++	if(ctxt->mode == X86EMUL_MODE_REAL || ctxt->mode == X86EMUL_MODE_VM86)
++		return emulate_ud(ctxt);
++
++	if(!(em_syscall_is_enabled(ctxt)))
++		return emulate_ud(ctxt);
++
++	if(ctxt->ops->cpl(ctxt) != 0) {
++		return emulate_gp(ctxt, 0);
++	}
++
++	//check if RCX is in canonical form
++	rcx = reg_read(ctxt, VCPU_REGS_RCX);
++	if(((rcx & 0xFFFF800000000000) != 0xFFFF800000000000)
++			&& ((rcx & 0x00007FFFFFFFFFFF) != rcx)) {
++		return emulate_gp(ctxt, 0);
++	}
++
++	ops->get_msr(ctxt, MSR_EFER, &efer);
++	setup_syscalls_segments(&cs, &ss);
++
++	if (!(efer & EFER_SCE))
++		return emulate_ud(ctxt);
++
++	ops->get_msr(ctxt, MSR_STAR, &msr_data);
++	msr_data >>= 48;
++
++	//setup code segment, atleast what is left to do.
++	//setup_syscalls_segments does most of the work for us
++	if(ctxt->mode == X86EMUL_MODE_PROT64) { //if longmode
++		cs_sel = (u16)((msr_data + 0x10) | 0x3);
++		cs.l = 1;
++		cs.d = 0;
++	} else {
++		cs_sel = (u16)(msr_data | 0x3);
++		cs.l = 0;
++		cs.d = 1;
++	}
++	cs.dpl = 0x3;
++
++	//setup stack segment, atleast what is left to do.
++	//setup_syscalls_segments does most of the work for us
++	ss_sel = (u16)((msr_data + 0x8) | 0x3);
++	ss.dpl = 0x3;
++
++	ops->set_segment(ctxt, cs_sel, &cs, 0, VCPU_SREG_CS);
++	ops->set_segment(ctxt, ss_sel, &ss, 0, VCPU_SREG_SS);
++
++	ctxt->eflags = (reg_read(ctxt, VCPU_REGS_R11) & 0x3c7fd7) | 0x2;
++
++	ctxt->_eip = reg_read(ctxt, VCPU_REGS_RCX);
++
++	return X86EMUL_CONTINUE;
++}
++
+ static int em_sysenter(struct x86_emulate_ctxt *ctxt)
+ {
+ 	const struct x86_emulate_ops *ops = ctxt->ops;
+@@ -4402,7 +4465,7 @@ static const struct opcode twobyte_table
+ 	/* 0x00 - 0x0F */
+ 	G(0, group6), GD(0, &group7), N, N,
+ 	N, I(ImplicitOps | EmulateOnUD | IsBranch, em_syscall),
+-	II(ImplicitOps | Priv, em_clts, clts), N,
++	II(ImplicitOps | Priv, em_clts, clts), I(ImplicitOps | EmulateOnUD, em_sysret),
+ 	DI(ImplicitOps | Priv, invd), DI(ImplicitOps | Priv, wbinvd), N, N,
+ 	N, D(ImplicitOps | ModRM | SrcMem | NoAccess), N, N,
+ 	/* 0x10 - 0x1F */
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/irq.c
+===================================================================
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/irq.c
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/irq.c
+@@ -58,6 +58,9 @@ int kvm_cpu_has_extint(struct kvm_vcpu *
+ 	 * pending interrupt or should re-inject an injected
+ 	 * interrupt.
+ 	 */
++	if (v->monitor_trap_flag)
++		return 0;
++
+ 	if (!lapic_in_kernel(v))
+ 		return v->arch.interrupt.injected;
+ 
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/capabilities.h
+===================================================================
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/vmx/capabilities.h
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/capabilities.h
+@@ -71,6 +71,7 @@ extern struct vmcs_config vmcs_config __
+ struct vmx_capability {
+ 	u32 ept;
+ 	u32 vpid;
++	bool mtf;
+ };
+ extern struct vmx_capability vmx_capability __ro_after_init;
+ 
+@@ -116,6 +117,11 @@ static inline bool cpu_has_vmx_tpr_shado
+ 	return vmcs_config.cpu_based_exec_ctrl & CPU_BASED_TPR_SHADOW;
+ }
+ 
++static inline bool cpu_has_monitor_trap_flag(void)
++{
++	return vmx_capability.mtf;
++}
++
+ static inline bool cpu_need_tpr_shadow(struct kvm_vcpu *vcpu)
+ {
+ 	return cpu_has_vmx_tpr_shadow() && lapic_in_kernel(vcpu);
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
+===================================================================
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/vmx/vmx.c
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/vmx/vmx.c
+@@ -874,7 +874,7 @@ void vmx_update_exception_bitmap(struct
+ 	 * We intercept those #GP and allow access to them anyway
+ 	 * as VMware does.
+ 	 */
+-	if (enable_vmware_backdoor)
++	if (enable_vmware_backdoor | vcpu->syscall_hook_enabled)
+ 		eb |= (1u << GP_VECTOR);
+ 	if ((vcpu->guest_debug &
+ 	     (KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP)) ==
+@@ -1107,6 +1107,11 @@ static bool update_transition_efer(struc
+ 		ignore_bits &= ~(u64)EFER_SCE;
+ #endif
+ 
++	/* IntroVirt patch to intercept system calls */
++	if (vmx->vcpu.syscall_hook_enabled) {
++		guest_efer &= ~EFER_SCE;
++	}
++
+ 	/*
+ 	 * On EPT, we can't emulate NX, so we must switch EFER atomically.
+ 	 * On CPUs that support "load IA32_EFER", always switch EFER
+@@ -2010,7 +2015,8 @@ static int vmx_get_msr(struct kvm_vcpu *
+ 		msr_info->data = to_vmx(vcpu)->spec_ctrl;
+ 		break;
+ 	case MSR_IA32_SYSENTER_CS:
+-		msr_info->data = vmcs_read32(GUEST_SYSENTER_CS);
++		/* IntroVirt Patch - Always return our shadow */
++		msr_info->data = vcpu->shadow_msr_ia32_sysenter_cs;
+ 		break;
+ 	case MSR_IA32_SYSENTER_EIP:
+ 		msr_info->data = vmcs_readl(GUEST_SYSENTER_EIP);
+@@ -2615,6 +2621,13 @@ static int setup_vmcs_config(struct vmcs
+ 				SECONDARY_EXEC_VIRTUALIZE_X2APIC_MODE |
+ 				SECONDARY_EXEC_VIRTUAL_INTR_DELIVERY);
+ 
++	if (_cpu_based_exec_control & CPU_BASED_MONITOR_TRAP_FLAG) {
++		_cpu_based_exec_control &= ~CPU_BASED_MONITOR_TRAP_FLAG;
++		vmx_cap->mtf = true;
++	} else {
++		vmx_cap->mtf = false;
++	}
++
+ 	rdmsr_safe(MSR_IA32_VMX_EPT_VPID_CAP,
+ 		&vmx_cap->ept, &vmx_cap->vpid);
+ 
+@@ -5209,7 +5222,7 @@ static int handle_exception_nmi(struct k
+ 		error_code = vmcs_read32(VM_EXIT_INTR_ERROR_CODE);
+ 
+ 	if (!vmx->rmode.vm86_active && is_gp_fault(intr_info)) {
+-		WARN_ON_ONCE(!enable_vmware_backdoor);
++		/* WARN_ON_ONCE(!enable_vmware_backdoor); */
+ 
+ 		/*
+ 		 * VMware backdoor emulation on #GP interception only handles
+@@ -5311,6 +5324,24 @@ static int handle_exception_nmi(struct k
+ 		kvm_run->exit_reason = KVM_EXIT_DEBUG;
+ 		kvm_run->debug.arch.pc = kvm_get_linear_rip(vcpu);
+ 		kvm_run->debug.arch.exception = ex_no;
++
++		/*
++		 * Check if we have an introspection client attached
++		 */
++		if(vcpu->introspection_mm)
++		{
++			if(ex_no == BP_VECTOR)
++			{
++				/*
++				 *  Deliver the event to the introspection handler,
++				 *  instead of exiting to QEMU.
++				 */
++				kvm_deliver_trap_event(vcpu, ex_no);
++
++				return 1;
++			}
++		}
++
+ 		break;
+ 	case AC_VECTOR:
+ 		if (vmx_guest_inject_ac(vcpu)) {
+@@ -5453,19 +5484,25 @@ static int handle_cr(struct kvm_vcpu *vc
+ 		trace_kvm_cr_write(cr, val);
+ 		switch (cr) {
+ 		case 0:
++			kvm_deliver_cr_write_event(vcpu, 0, val);
+ 			err = handle_set_cr0(vcpu, val);
++			/* These events are delivered here so that we know they're coming from the guest
++			 * kvm_set_cr0() would work as well, but we'd get events when it's set via ioctl.
++			 */
+ 			return kvm_complete_insn_gp(vcpu, err);
+ 		case 3:
+-			WARN_ON_ONCE(enable_unrestricted_guest);
+-
++			/*WARN_ON_ONCE(enable_unrestricted_guest);*/
++			kvm_deliver_cr_write_event(vcpu, 3, val);
+ 			err = kvm_set_cr3(vcpu, val);
+ 			return kvm_complete_insn_gp(vcpu, err);
+ 		case 4:
++			kvm_deliver_cr_write_event(vcpu, 4, val);
+ 			err = handle_set_cr4(vcpu, val);
+ 			return kvm_complete_insn_gp(vcpu, err);
+ 		case 8: {
+ 				u8 cr8_prev = kvm_get_cr8(vcpu);
+ 				u8 cr8 = (u8)val;
++				kvm_deliver_cr_write_event(vcpu, 8, val);
+ 				err = kvm_set_cr8(vcpu, cr8);
+ 				ret = kvm_complete_insn_gp(vcpu, err);
+ 				if (lapic_in_kernel(vcpu))
+@@ -5493,11 +5530,13 @@ static int handle_cr(struct kvm_vcpu *vc
+ 			val = kvm_read_cr3(vcpu);
+ 			kvm_register_write(vcpu, reg, val);
+ 			trace_kvm_cr_read(cr, val);
++			kvm_deliver_cr_read_event(vcpu, 3, val);
+ 			return kvm_skip_emulated_instruction(vcpu);
+ 		case 8:
+ 			val = kvm_get_cr8(vcpu);
+ 			kvm_register_write(vcpu, reg, val);
+ 			trace_kvm_cr_read(cr, val);
++			kvm_deliver_cr_read_event(vcpu, 8, val);
+ 			return kvm_skip_emulated_instruction(vcpu);
+ 		}
+ 		break;
+@@ -5932,6 +5971,11 @@ static int handle_pause(struct kvm_vcpu
+ 
+ static int handle_monitor_trap(struct kvm_vcpu *vcpu)
+ {
++	/*
++	* If introspection is enabled, deliver the event.
++	*/
++	if(vcpu->introspection_mm)
++		kvm_deliver_monitor_trap_flag_event(vcpu);
+ 	return 1;
+ }
+ 
+@@ -7502,7 +7546,8 @@ static int vmx_vcpu_create(struct kvm_vc
+ 	vmx_disable_intercept_for_msr(vcpu, MSR_GS_BASE, MSR_TYPE_RW);
+ 	vmx_disable_intercept_for_msr(vcpu, MSR_KERNEL_GS_BASE, MSR_TYPE_RW);
+ #endif
+-	vmx_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_CS, MSR_TYPE_RW);
++	/* IntroVirt patch */
++	/* vmx_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_CS, MSR_TYPE_RW); */
+ 	vmx_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_ESP, MSR_TYPE_RW);
+ 	vmx_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_EIP, MSR_TYPE_RW);
+ 	if (kvm_cstate_in_guest(vcpu->kvm)) {
+@@ -8252,6 +8297,102 @@ gva_t vmx_get_untagged_addr(struct kvm_v
+ 	return (sign_extend64(gva, lam_bit) & ~BIT_ULL(63)) | (gva & BIT_ULL(63));
+ }
+ 
++static int vmx_set_cr_monitor(struct kvm_vcpu *vcpu, int cr, int mode)
++{
++	struct vcpu_vmx *vmx = to_vmx(vcpu);
++
++	if (unlikely(mode > 0x3)) {
++		printk ("Invalid mode 0x%X passed to KVM_SET_CR_MONITOR\n", mode);
++		return -EINVAL;
++	}
++
++	switch (cr)
++	{
++		// We can only monitor writes to CR 0 and 4
++		case 0:
++		case 4:
++			if (mode & KVM_MONITOR_CR_READ) {
++				printk(KERN_WARNING "Tried to enable CR%d read monitoring, but unsupported\n", cr);
++				return -ENODEV;
++			}
++			break;
++		case 3:
++			exec_controls_clearbit(vmx, CPU_BASED_CR3_LOAD_EXITING | CPU_BASED_CR3_STORE_EXITING);
++
++			if (mode & KVM_MONITOR_CR_WRITE)
++				exec_controls_setbit(vmx, CPU_BASED_CR3_LOAD_EXITING);
++			if (mode & KVM_MONITOR_CR_READ)
++				exec_controls_setbit(vmx, CPU_BASED_CR3_STORE_EXITING);
++			break;
++		case 8:
++			exec_controls_clearbit(vmx, CPU_BASED_CR8_LOAD_EXITING | CPU_BASED_CR8_STORE_EXITING);
++
++			if (mode & KVM_MONITOR_CR_WRITE)
++				exec_controls_setbit(vmx, CPU_BASED_CR8_LOAD_EXITING);
++			if (mode & KVM_MONITOR_CR_READ)
++				exec_controls_setbit(vmx, CPU_BASED_CR8_STORE_EXITING);
++			break;
++		default:
++			return -ENODEV;
++	}
++
++	// Update the VCPU mask, checked by event delivery
++	vcpu->cr_monitor_mask &= ~(0x3 << (cr * 2));
++	vcpu->cr_monitor_mask |= (mode << (cr * 2));
++
++	if (!enable_ept)
++	{
++		// Without EPT, we always need CR3 intercepts
++		exec_controls_setbit(vmx, CPU_BASED_CR3_LOAD_EXITING | CPU_BASED_CR3_STORE_EXITING);
++	}
++
++	return 0;
++}
++
++static int vmx_set_monitor_trap_flag(struct kvm_vcpu *vcpu, bool enabled) {
++	struct vcpu_vmx *vmx = to_vmx(vcpu);
++
++	if (!cpu_has_monitor_trap_flag())
++		return -ENODEV;
++
++	vcpu->monitor_trap_flag = enabled;
++
++	if (enabled)
++		exec_controls_setbit(vmx, CPU_BASED_MONITOR_TRAP_FLAG);
++	else
++		exec_controls_clearbit(vmx, CPU_BASED_MONITOR_TRAP_FLAG);
++	return 0;
++}
++
++static int vmx_set_invlpg_monitor(struct kvm_vcpu *vcpu, bool enabled) {
++	struct vcpu_vmx *vmx = to_vmx(vcpu);
++
++	/* Without ept, we always need it set */
++	if (enabled || !enable_ept)
++		exec_controls_setbit(vmx, CPU_BASED_INVLPG_EXITING);
++	else
++		exec_controls_clearbit(vmx, CPU_BASED_INVLPG_EXITING);
++
++	vcpu->invlpg_hook = enabled;
++
++	return 0;
++}
++
++static bool vmx_hap_permissions_allowed(uint16_t perms) {
++	if ((perms & PT_PRESENT_MASK) == 0)
++	{
++		if ((perms & PT_WRITABLE_MASK))
++			// Not allowed to do write-only or write+execute.
++			// You have to have read for those.
++			return false;
++		else if ((perms & PT_USER_MASK))
++			// Execute only. This is only supported if a feature bit is set.
++			if (!cpu_has_vmx_ept_execute_only())
++				return false;
++	}
++	return true;
++}
++
+ static struct kvm_x86_ops vmx_x86_ops __initdata = {
+ 	.name = KBUILD_MODNAME,
+ 
+@@ -8394,6 +8535,13 @@ static struct kvm_x86_ops vmx_x86_ops __
+ 	.vcpu_deliver_sipi_vector = kvm_vcpu_deliver_sipi_vector,
+ 
+ 	.get_untagged_addr = vmx_get_untagged_addr,
++
++	/* IntroVirt patch */
++	.update_syscall_intercept = vmx_update_exception_bitmap,
++	.set_cr_monitor = vmx_set_cr_monitor,
++	.set_monitor_trap_flag = vmx_set_monitor_trap_flag,
++	.set_invlpg_monitor = vmx_set_invlpg_monitor,
++	.hap_permissions_allowed = vmx_hap_permissions_allowed,
+ };
+ 
+ static unsigned int vmx_handle_intel_pt_intr(void)
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
+===================================================================
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/x86.c
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/x86.c
+@@ -129,6 +129,11 @@ static void store_regs(struct kvm_vcpu *
+ static int sync_regs(struct kvm_vcpu *vcpu);
+ static int kvm_vcpu_do_singlestep(struct kvm_vcpu *vcpu);
+ 
++/* IntroVirt introspection patch */
++void kvm_arch_clear_mem_access(struct kvm* kvm);
++static void init_emulate_ctxt(struct kvm_vcpu *vcpu);
++static void toggle_interruptibility(struct kvm_vcpu *vcpu, u32 mask);
++
+ static int __set_sregs2(struct kvm_vcpu *vcpu, struct kvm_sregs2 *sregs2);
+ static void __get_sregs2(struct kvm_vcpu *vcpu, struct kvm_sregs2 *sregs2);
+ 
+@@ -1870,6 +1875,15 @@ static int __kvm_set_msr(struct kvm_vcpu
+ 		 */
+ 		data = __canonical_address(data, vcpu_virt_addr_bits(vcpu));
+ 		break;
++	case MSR_IA32_SYSENTER_CS:
++		/*
++		 * Any time there's a write to this MSR, update the shadow.
++		 * Also, switch it to 0 if we are intercepting system calls.
++		 */
++		vcpu->shadow_msr_ia32_sysenter_cs = data;
++		if (vcpu->syscall_hook_enabled)
++			data = 0;
++		break;
+ 	case MSR_TSC_AUX:
+ 		if (!kvm_is_supported_user_return_msr(MSR_TSC_AUX))
+ 			return 1;
+@@ -4785,6 +4799,9 @@ int kvm_vm_ioctl_check_extension(struct
+ 		if (kvm_is_vm_type_supported(KVM_X86_SW_PROTECTED_VM))
+ 			r |= BIT(KVM_X86_SW_PROTECTED_VM);
+ 		break;
++	case KVM_CAP_INTROSPECTION:
++		r = KVM_INTROSPECTION_API_VERSION;
++		break;
+ 	default:
+ 		break;
+ 	}
+@@ -5801,6 +5818,26 @@ static int kvm_vcpu_ioctl_enable_cap(str
+ 	}
+ }
+ 
++static int kvm_set_syscall_hook(struct kvm_vcpu *vcpu, bool enabled)
++{
++	int rc = 0;
++	if (vcpu->syscall_hook_enabled == enabled)
++		goto done;
++
++    vcpu->syscall_hook_enabled = enabled;
++
++	// Update the efer using the new 'syscall_hook_enabled' setting.
++	kvm_x86_ops.set_efer(vcpu, vcpu->arch.efer);
++
++	// Update MSR_IA32_SYSENTER_CS
++	kvm_set_msr(vcpu, MSR_IA32_SYSENTER_CS, vcpu->shadow_msr_ia32_sysenter_cs);
++
++	// Turn on or off #GP intercept
++	kvm_x86_ops.update_syscall_intercept(vcpu);
++done:
++	return rc;
++}
++
+ long kvm_arch_vcpu_ioctl(struct file *filp,
+ 			 unsigned int ioctl, unsigned long arg)
+ {
+@@ -6235,6 +6272,107 @@ long kvm_arch_vcpu_ioctl(struct file *fi
+ 	case KVM_SET_DEVICE_ATTR:
+ 		r = kvm_vcpu_ioctl_device_attr(vcpu, ioctl, argp);
+ 		break;
++	case KVM_SET_CR_MONITOR: {
++		struct kvm_cr_monitor cr_mon;
++
++		r = -EFAULT;
++		if (copy_from_user(&cr_mon, argp, sizeof(cr_mon)))
++			goto out;
++
++		r = kvm_x86_ops.set_cr_monitor(vcpu, cr_mon.cr, cr_mon.mode);
++		break;
++	}
++	case KVM_SET_INVLPG_HOOK: {
++		r = kvm_x86_ops.set_invlpg_monitor(vcpu, arg);
++		break;
++	}
++	case KVM_SET_MONITOR_TRAP_FLAG: {
++		r = kvm_x86_ops.set_monitor_trap_flag(vcpu, arg);
++		break;
++	}
++	case KVM_SET_SYSCALL_HOOK: {
++		r = kvm_set_syscall_hook(vcpu, arg);
++		break;
++	}
++	case KVM_SET_VMCALL_HOOK: {
++		r = 0;
++		vcpu->vmcall_hook_enabled = (arg != 0);
++		break;
++	}
++	case KVM_INJECT_TRAP: {
++		struct kvm_inject_trap trap;
++		r = -EFAULT;
++		if (copy_from_user(&trap, argp, sizeof(trap)))
++			goto out;
++
++		if(trap.vector == PF_VECTOR) {
++			vcpu->arch.cr2 = trap.cr2;
++		}
++		kvm_multiple_exception(vcpu, trap.vector, trap.has_error, trap.error_code, false, 0, false);
++		r = 0;
++
++		break;
++	}
++	case KVM_VCPU_INJECT_SYSENTER:
++	case KVM_VCPU_INJECT_SYSCALL: {
++		struct x86_emulate_ctxt *ctxt = vcpu->arch.emulate_ctxt;
++		uint8_t insn[8];
++		int insn_len = 0;
++		unsigned long rflags = kvm_x86_ops.get_rflags(vcpu);
++		struct kvm_segment cs;
++
++		// Check CS for long mode
++		kvm_get_segment(vcpu, &cs, VCPU_SREG_CS);
++
++		init_emulate_ctxt(vcpu);
++
++		ctxt->interruptibility = 0;
++		ctxt->have_exception = false;
++		ctxt->exception.vector = -1;
++		ctxt->perm_ok = false;
++
++		if (ioctl == KVM_VCPU_INJECT_SYSCALL)
++		{
++			// SYSCALL
++			if (cs.l)
++				insn[insn_len++] = 0x48;
++			insn[insn_len++] = 0x0F;
++			insn[insn_len++] = 0x05;
++		} else {
++			// SYSENTER
++			if (cs.l)
++				insn[insn_len++] = 0x48;
++			insn[insn_len++] = 0x0F;
++			insn[insn_len++] = 0x34;
++		}
++
++		r = x86_decode_insn(ctxt, insn, insn_len, 0);
++		if (r != EMULATION_OK) {
++			printk(KERN_WARNING "x86_decode_insn failed: %d\n", r);
++			break;
++		}
++
++		r = x86_emulate_insn(ctxt);
++		if (r != EMULATION_OK)
++			break;
++
++		kvm_rip_write(vcpu, ctxt->eip);
++		__kvm_set_rflags(vcpu, ctxt->eflags);
++		emulator_writeback_register_cache(ctxt);
++		vcpu->arch.emulate_regs_need_sync_to_vcpu = false;
++		toggle_interruptibility(vcpu, ctxt->interruptibility);
++
++		/*
++		 * For STI, interrupts are shadowed; so KVM_REQ_EVENT will
++		 * do nothing, and it will be requested again as soon as
++		 * the shadow expires.  But we still need to check here,
++		 * because POPF has no interrupt shadow.
++		 */
++		if (unlikely((ctxt->eflags & ~rflags) & X86_EFLAGS_IF))
++			kvm_make_request(KVM_REQ_EVENT, vcpu);
++
++		break;
++	}
+ 	default:
+ 		r = -EINVAL;
+ 	}
+@@ -7267,6 +7405,101 @@ set_pit2_out:
+ 		r = kvm_vm_ioctl_set_msr_filter(kvm, &filter);
+ 		break;
+ 	}
++	case KVM_SET_MEM_ACCESS_ENABLED: {
++		kvm->mem_event_enabled = arg;
++		printk(KERN_DEBUG "IV-x86: Memory access events %s\n",
++		       kvm->mem_event_enabled ? "enabled" : "disabled");
++
++		/* TODO: Check if EPT is enabled; it's the only one we support right now. */
++
++		r = 0;
++		if (!kvm->mem_event_enabled) {
++			/* Remove all entries */
++			kvm_arch_clear_mem_access(kvm);
++		}
++		break;
++	}
++	case KVM_SET_MEM_ACCESS: {
++		unsigned long i;
++		struct kvm_ept_permissions perms;
++		struct kvm_vcpu *vcpu = NULL;
++		struct mem_access_entry * entry;
++
++		r = -EINVAL;
++		if (unlikely(xa_empty(&kvm->vcpu_array)))
++			goto out;
++
++		r = -EINVAL;
++		if (unlikely(!kvm->mem_event_enabled))
++			goto out;
++
++		r = -EFAULT;
++		if (copy_from_user(&perms, argp, sizeof(perms)))
++			goto out;
++
++		mutex_lock(&kvm->mem_access_table.mutex);
++
++		kvm_for_each_vcpu(i, vcpu, kvm) {
++			break;  // Just need the first one
++		}
++
++		// Search for the entry
++		hash_for_each_possible(kvm->mem_access_table.table, entry, node, perms.gfn)
++		{
++			if (entry->gfn == perms.gfn)
++			{
++				printk(KERN_DEBUG "IV-x86: Found existing mem access entry for GFN 0x%08llx. Updating perms: 0x%x\n",
++				       perms.gfn, perms.perms);
++				/* This entry already exists */
++				/* Set the requested permissions */
++				r = vcpu->arch.mmu->set_pte_perms(vcpu, perms.gfn, perms.perms, NULL);
++				if (r) {
++					printk(KERN_ERR "IV-x86: Failed to set PTE perms for GFN 0x%08llx. %d\n", perms.gfn, r);
++					goto set_ept_out;
++				}
++
++				if (perms.perms == entry->original_perms)
++				{
++					/* Setting back to original permissions, just remove the entry */
++					hash_del(&entry->node);
++					printk(KERN_DEBUG "IV-x86: Removed mem access entry for GFN 0x%08llx. Restored perms: 0x%x\n",
++					       perms.gfn, entry->original_perms);
++					kfree(entry);
++					r = 0;
++				}
++				goto set_ept_out;
++			}
++		}
++
++		r = 0;
++		/* Don't bother adding an entry when setting full permissions */
++		if (perms.perms != (PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK))
++		{
++			/* We didn't find an existing entry, add a new one. */
++			r = -ENOMEM;
++			entry = kmalloc(sizeof(struct mem_access_entry), GFP_KERNEL);
++			if(!entry)
++				goto set_ept_out;
++			entry->gfn = perms.gfn;
++
++			/* Update the PTE */
++			r = vcpu->arch.mmu->set_pte_perms(vcpu, perms.gfn, perms.perms, &entry->original_perms);
++			if (r)
++			{
++				// Failed to set PTE permissions, so free the entry
++				printk(KERN_ERR "IV-x86: Failed to set PTE perms for GFN 0x%08llx. %d\n", perms.gfn, r);
++				kfree(entry);
++				goto set_ept_out;
++			}
++			/* Add the entry to the table */
++			hash_add(kvm->mem_access_table.table, &entry->node, perms.gfn);
++			printk(KERN_DEBUG "IV-x86: Added mem access entry for GFN 0x%08llx. New perms: 0x%x\n",
++			       perms.gfn, perms.perms);
++		}
++set_ept_out:
++		mutex_unlock(&kvm->mem_access_table.mutex);
++		break;
++	}
+ 	default:
+ 		r = -ENOTTY;
+ 	}
+@@ -9061,6 +9294,8 @@ int x86_emulate_instruction(struct kvm_v
+ 	int r;
+ 	struct x86_emulate_ctxt *ctxt = vcpu->arch.emulate_ctxt;
+ 	bool writeback = true;
++	bool sysret = false;
++	bool sysexit = false;
+ 
+ 	r = kvm_check_emulate_insn(vcpu, emulation_type, insn, insn_len);
+ 	if (r != X86EMUL_CONTINUE) {
+@@ -9111,10 +9346,54 @@ int x86_emulate_instruction(struct kvm_v
+ 		}
+ 	}
+ 
+-	if ((emulation_type & EMULTYPE_VMWARE_GP) &&
+-	    !is_vmware_backdoor_opcode(ctxt)) {
+-		kvm_queue_exception_e(vcpu, GP_VECTOR, 0);
+-		return 1;
++	if (ctxt->d) {
++		int i = 0;
++
++		if(ctxt->fetch.data[0] == 0x48)
++			++i; // Skip over the REX.W prefix
++
++		if(ctxt->fetch.data[i] == 0x0F) {
++			switch(ctxt->fetch.data[i + 1]) {
++			case 0x05: { // SYSCALL
++				const u64 original_rip = kvm_rip_read(vcpu);
++				kvm_deliver_syscall_event(vcpu, original_rip + ctxt->opcode_len);
++				if (kvm_rip_read(vcpu) != original_rip || vcpu->arch.exception.pending)
++				    return 1;
++				break;
++			}
++			case 0x07: // SYSRET
++				sysret = true;
++				break;
++			}
++		}
++	} else if (emulation_type & EMULTYPE_VMWARE_GP) {
++		int i = 0;
++		bool handled = false;
++
++		if(ctxt->fetch.data[0] == 0x48)
++			++i; // Skip over the REX.W prefix
++
++		if(ctxt->fetch.data[i] == 0x0F) {
++			switch(ctxt->fetch.data[i + 1]) {
++			case 0x34: { /* SYSENTER */
++				const u64 original_rip = kvm_rip_read(vcpu);
++				kvm_deliver_sysenter_event(vcpu, original_rip + ctxt->opcode_len);
++				if (kvm_rip_read(vcpu) != original_rip || vcpu->arch.exception.pending)
++				    return 1;
++				handled = true;
++			    break;
++			}
++			case 0x35: /* SYSEXIT */
++				sysexit = true;
++				handled = true;
++				break;
++			}
++		}
++
++		if (!handled && !is_vmware_backdoor_opcode(ctxt)) {
++			kvm_queue_exception_e(vcpu, GP_VECTOR, 0);
++			return 1;
++		}
+ 	}
+ 
+ 	/*
+@@ -9240,6 +9519,11 @@ writeback:
+ 	} else
+ 		vcpu->arch.emulate_regs_need_sync_to_vcpu = true;
+ 
++	if (sysret)
++		kvm_deliver_sysret_event(vcpu);
++	else if (sysexit)
++		kvm_deliver_sysexit_event(vcpu);
++
+ 	return r;
+ }
+ 
+@@ -9813,6 +10097,51 @@ void kvm_x86_vendor_exit(void)
+ }
+ EXPORT_SYMBOL_GPL(kvm_x86_vendor_exit);
+ 
++void kvm_arch_clear_mem_access(struct kvm* kvm) {
++	unsigned long i;
++	struct kvm_vcpu * vcpu = NULL;
++	struct mem_access_entry * entry;
++	struct hlist_node * tmp;
++	int bkt;
++
++	printk(KERN_DEBUG "IV-x86: Clearing memory access table\n");
++
++	/* Remove all entries */
++	mutex_lock(&kvm->mem_access_table.mutex);
++
++
++	kvm_for_each_vcpu(i, vcpu, kvm) {
++		break; // Just need first VCPU
++	}
++
++	hash_for_each_safe(kvm->mem_access_table.table, bkt, tmp, entry, node)
++	{
++		/* Set the mem_access values back to normal */
++		printk(KERN_DEBUG "IV-x86: \tRestoring GFN 0x%08llx perms to 0x%x\n",
++		       entry->gfn, entry->original_perms);
++		vcpu->arch.mmu->set_pte_perms(vcpu, entry->gfn, entry->original_perms, NULL);
++
++		hash_del(&entry->node);
++		kfree(entry);
++	}
++	mutex_unlock(&kvm->mem_access_table.mutex);
++}
++
++void kvm_arch_introspection_cleanup(struct kvm_vcpu *vcpu)
++{
++	printk(KERN_DEBUG "IV-x86: Cleaning up introspection state for vCPU %d\n", vcpu->vcpu_id);
++	int i;
++	for (i=0; i<=8; ++i) {
++		kvm_x86_ops.set_cr_monitor(vcpu, i, 0);
++	}
++	kvm_arch_clear_mem_access(vcpu->kvm);
++	kvm_set_syscall_hook(vcpu, 0);
++	kvm_x86_ops.set_monitor_trap_flag(vcpu, 0);
++	kvm_x86_ops.set_invlpg_monitor(vcpu, 0);
++	vcpu->kvm->mem_event_enabled = 0;
++	vcpu->vmcall_hook_enabled = 0;
++}
++
+ static int __kvm_emulate_halt(struct kvm_vcpu *vcpu, int state, int reason)
+ {
+ 	/*
+@@ -10005,13 +10334,33 @@ int kvm_emulate_hypercall(struct kvm_vcp
+ 	unsigned long nr, a0, a1, a2, a3, ret;
+ 	int op_64_bit;
+ 
++	nr = kvm_rax_read(vcpu);
++	if(nr == 0xFACE)
++	{
++		const uint64_t original_rip = kvm_rip_read(vcpu);
++		printk(KERN_DEBUG "IV-x86: Received introspection hypercall from guest VCPU %d, original RIP: 0x%08llx\n", vcpu->vcpu_id, original_rip);
++
++		if (vcpu->vmcall_hook_enabled) {
++			printk(KERN_DEBUG "IV-x86: Delivering introspection hypercall event to host for guest VCPU %d\n", vcpu->vcpu_id);
++			kvm_deliver_vmcall_event(vcpu);
++		}
++
++		++vcpu->stat.hypercalls;
++		if (original_rip == kvm_rip_read(vcpu)) {
++			printk(KERN_DEBUG "IV-x86: Hypercall handler did not change RIP, skipping instruction for guest VCPU %d\n", vcpu->vcpu_id);
++			return kvm_skip_emulated_instruction(vcpu);
++		}
++		printk(KERN_DEBUG "IV-x86: Hypercall handler changed RIP to 0x%08lx for guest VCPU %d\n", kvm_rip_read(vcpu), vcpu->vcpu_id);
++		return 0;
++	}
++
+ 	if (kvm_xen_hypercall_enabled(vcpu->kvm))
+ 		return kvm_xen_hypercall(vcpu);
+ 
+ 	if (kvm_hv_hypercall_enabled(vcpu))
+ 		return kvm_hv_hypercall(vcpu);
+ 
+-	nr = kvm_rax_read(vcpu);
++	/*nr = kvm_rax_read(vcpu);*/
+ 	a0 = kvm_rbx_read(vcpu);
+ 	a1 = kvm_rcx_read(vcpu);
+ 	a2 = kvm_rdx_read(vcpu);
+@@ -11170,6 +11519,26 @@ static int vcpu_run(struct kvm_vcpu *vcp
+ 			r = vcpu_block(vcpu);
+ 		}
+ 
++		/*
++		 * We shouldn't get here during an event
++		 * The vcpu will be blocked in event delivery
++		 */
++		if (atomic_read(&vcpu->pause_count)) {
++			// Release the vcpu
++			vcpu_put(vcpu);
++			mutex_unlock(&vcpu->mutex);
++
++			/* Wait until we're resumed */
++			wait_event(vcpu->pause_wait_queue,
++				atomic_read(&vcpu->pause_count) == 0);
++
++			/* Retake the vcpu */
++			if (mutex_lock_killable(&vcpu->mutex))
++				return -EINTR;
++
++			vcpu_load(vcpu);
++		}
++
+ 		if (r <= 0)
+ 			break;
+ 
+@@ -11725,6 +12094,12 @@ static int __set_sregs_common(struct kvm
+ 	*mmu_reset_needed |= kvm_read_cr0(vcpu) != sregs->cr0;
+ 	static_call(kvm_x86_set_cr0)(vcpu, sregs->cr0);
+ 
++	if (kvm_rip_read(vcpu) == 0xfff0) {
++		vcpu->reboot_pending = true;
++	} else {
++		vcpu->reboot_pending = false;
++	}
++
+ 	*mmu_reset_needed |= kvm_read_cr4(vcpu) != sregs->cr4;
+ 	static_call(kvm_x86_set_cr4)(vcpu, sregs->cr4);
+ 
+@@ -13539,6 +13914,213 @@ int kvm_spec_ctrl_test_value(u64 value)
+ }
+ EXPORT_SYMBOL_GPL(kvm_spec_ctrl_test_value);
+ 
++static void kvm_deliver_introspection_event(struct kvm_vcpu* vcpu,
++		struct kvm_introspection_event* event)
++{
++	if (!vcpu->introspection_mm)
++		return;
++
++	/*
++	 * Fill out the structure with registers and information
++	 */
++	event->event_id = atomic64_inc_return(&vcpu->kvm->event_id);
++	event->vcpu_id = vcpu->vcpu_id;
++    if (event->event_type != KVM_EVENT_SHUTDOWN) {
++	    __get_regs(vcpu, &event->regs);
++    	__get_sregs(vcpu, &event->sregs);
++    	kvm_vcpu_ioctl_x86_get_debugregs(vcpu, &event->debugregs);
++    }
++
++	mutex_lock(&vcpu->introspection_event_mutex);
++	if (unlikely(vcpu->introspection_event != NULL))
++		printk(KERN_ERR "IV-x86: Overwriting existing event %llu", event->event_id);
++
++	/*
++	 * Set the introspection event
++	 */
++	vcpu->introspection_event = event;
++	vcpu->introspection_event_pending_completion = true;
++	mutex_unlock(&vcpu->introspection_event_mutex);
++
++	/*
++	 * Release the vcpu while the event is being delivered.
++	 * If we don't do this, then ioctls will deadlock.
++	 */
++	if (likely(event->event_type != KVM_EVENT_SHUTDOWN)) {
++		if (unlikely(event->event_type == KVM_EVENT_HYPERCALL))
++			printk(KERN_DEBUG "IV-x86: Pausing vCPU %d for hypercall event %llu\n", vcpu->vcpu_id, event->event_id);
++		atomic_inc(&vcpu->pause_count);
++		vcpu_put(vcpu);
++		mutex_unlock(&vcpu->mutex);
++	}
++
++	/*
++	 * Wake up the userland call to poll()
++	 */
++	wake_up(&vcpu->introspection_wait_queue);
++
++	/*
++	 * Block until KVM_COMPLETE_INTROSPECTION_EVENT
++	 */
++	//printk(KERN_DEBUG "kvm: vCPU %d waiting for event %llu completion\n", vcpu->vcpu_id, event->event_id);
++	wait_event(vcpu->introspection_event_completed_wait_queue,
++		vcpu->introspection_event_pending_completion == false);
++
++	/*
++	* If we're still being introspected, decrement the pause count.
++	* Then retake the vcpu and continue on about our business.
++	*/
++	if (likely(event->event_type != KVM_EVENT_SHUTDOWN)) {
++		if (unlikely(event->event_type == KVM_EVENT_HYPERCALL)) {
++			printk(KERN_DEBUG "IV-x86: vCPU %d hypercall event %llu completed\n", vcpu->vcpu_id, event->event_id);
++		}
++
++		if (vcpu->introspection_mm) {
++			kvm_vcpu_unpause(vcpu);
++		}
++
++		if (mutex_lock_killable(&vcpu->mutex))
++			return;
++		vcpu_load(vcpu);
++	}
++}
++
++void kvm_deliver_invlpg_event(struct kvm_vcpu *vcpu, uint64_t gva) {
++	if (vcpu->invlpg_hook) {
++		struct kvm_introspection_event event;
++		event.event_type = KVM_EVENT_INVLPG;
++		event.invlpg.gva = gva;
++		kvm_deliver_introspection_event(vcpu, &event);
++	}
++}
++
++void kvm_deliver_mem_event(struct kvm_vcpu *vcpu, uint64_t gpa, u32 error_code) {
++	if (kvm_is_mem_event_enabled(vcpu->kvm)) {
++		struct kvm_introspection_event event;
++		event.event_type = KVM_EVENT_MEM_ACCESS;
++		event.mem_event.gpa = gpa;
++		event.mem_event.error_code = error_code;
++		kvm_deliver_introspection_event(vcpu, &event);
++	}
++}
++
++void kvm_deliver_cr_read_event(struct kvm_vcpu *vcpu, int cr, u64 val)
++{
++	if (kvm_is_cr_hooked(vcpu, cr, KVM_MONITOR_CR_READ))
++	{
++		struct kvm_introspection_event event;
++		event.event_type = KVM_EVENT_CR_READ;
++		event.cr_access.cr = cr;
++		event.cr_access.value = val;
++		kvm_deliver_introspection_event(vcpu, &event);
++	}
++}
++EXPORT_SYMBOL(kvm_deliver_cr_read_event);
++
++void kvm_deliver_cr_write_event(struct kvm_vcpu *vcpu, int cr, u64 val)
++{
++	if (kvm_is_cr_hooked(vcpu, cr, KVM_MONITOR_CR_WRITE))
++	{
++		struct kvm_introspection_event event;
++		event.event_type = KVM_EVENT_CR_WRITE;
++		event.cr_access.cr = cr;
++		event.cr_access.value = val;
++		kvm_deliver_introspection_event(vcpu, &event);
++	}
++}
++EXPORT_SYMBOL(kvm_deliver_cr_write_event);
++
++void kvm_deliver_syscall_event(struct kvm_vcpu *vcpu, u64 return_address)
++{
++	if (vcpu->syscall_hook_enabled)
++	{
++		struct kvm_introspection_event event;
++		event.event_type = KVM_EVENT_FAST_SYSCALL;
++		event.system_call.type = KVM_EVENT_SYSTEM_CALL_TYPE_SYSCALL;
++		event.system_call.return_address = return_address;
++		kvm_deliver_introspection_event(vcpu, &event);
++	}
++}
++EXPORT_SYMBOL(kvm_deliver_syscall_event);
++
++void kvm_deliver_sysenter_event(struct kvm_vcpu *vcpu, u64 return_address)
++{
++	if (vcpu->syscall_hook_enabled)
++	{
++		struct kvm_introspection_event event;
++		event.event_type = KVM_EVENT_FAST_SYSCALL;
++		event.system_call.type = KVM_EVENT_SYSTEM_CALL_TYPE_SYSENTER;
++		event.system_call.return_address = return_address;
++		kvm_deliver_introspection_event(vcpu, &event);
++	}
++}
++EXPORT_SYMBOL(kvm_deliver_sysenter_event);
++
++void kvm_deliver_sysret_event(struct kvm_vcpu *vcpu)
++{
++	struct kvm_introspection_event event;
++	if (vcpu->syscall_hook_enabled)
++	{
++		event.event_type = KVM_EVENT_FAST_SYSCALL_RET;
++		event.system_call_ret.type = KVM_EVENT_FAST_SYSCALL_RET;
++		kvm_deliver_introspection_event(vcpu, &event);
++	}
++}
++EXPORT_SYMBOL(kvm_deliver_sysret_event);
++
++void kvm_deliver_sysexit_event(struct kvm_vcpu *vcpu)
++{
++	struct kvm_introspection_event event;
++	if (vcpu->syscall_hook_enabled)
++	{
++		event.event_type = KVM_EVENT_FAST_SYSCALL_RET;
++		event.system_call_ret.type = KVM_EVENT_SYSTEM_CALL_RET_TYPE_SYSEXIT;
++		kvm_deliver_introspection_event(vcpu, &event);
++	}
++}
++EXPORT_SYMBOL(kvm_deliver_sysexit_event);
++
++void kvm_deliver_vmcall_event(struct kvm_vcpu *vcpu)
++{
++	struct kvm_introspection_event event;
++	event.event_type = KVM_EVENT_HYPERCALL;
++	kvm_deliver_introspection_event(vcpu, &event);
++}
++EXPORT_SYMBOL(kvm_deliver_vmcall_event);
++
++void kvm_deliver_trap_event(struct kvm_vcpu *vcpu, int vector)
++{
++	struct kvm_introspection_event event;
++	event.event_type = KVM_EVENT_EXCEPTION;
++	event.trap.vector = vector;
++	kvm_deliver_introspection_event(vcpu, &event);
++}
++EXPORT_SYMBOL(kvm_deliver_trap_event);
++
++void kvm_deliver_monitor_trap_flag_event(struct kvm_vcpu *vcpu)
++{
++	struct kvm_introspection_event event;
++	event.event_type = KVM_EVENT_SINGLE_STEP;
++	kvm_deliver_introspection_event(vcpu, &event);
++}
++EXPORT_SYMBOL(kvm_deliver_monitor_trap_flag_event);
++
++void kvm_deliver_reboot_event(struct kvm_vcpu *vcpu)
++{
++	struct kvm_introspection_event event;
++	event.event_type = KVM_EVENT_REBOOT;
++	kvm_deliver_introspection_event(vcpu, &event);
++}
++EXPORT_SYMBOL(kvm_deliver_reboot_event);
++
++void kvm_deliver_shutdown_event(struct kvm_vcpu *vcpu)
++{
++	struct kvm_introspection_event event;
++	event.event_type = KVM_EVENT_SHUTDOWN;
++	kvm_deliver_introspection_event(vcpu, &event);
++}
++EXPORT_SYMBOL(kvm_deliver_shutdown_event);
++
+ void kvm_fixup_and_inject_pf_error(struct kvm_vcpu *vcpu, gva_t gva, u16 error_code)
+ {
+ 	struct kvm_mmu *mmu = vcpu->arch.walk_mmu;
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/x86.h
+===================================================================
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/x86.h
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/x86.h
+@@ -322,6 +322,29 @@ int x86_emulate_instruction(struct kvm_v
+ 			    int emulation_type, void *insn, int insn_len);
+ fastpath_t handle_fastpath_set_msr_irqoff(struct kvm_vcpu *vcpu);
+ 
++static inline int kvm_is_cr_hooked(struct kvm_vcpu *vcpu, int cr, int mode)
++{
++	return (((vcpu->cr_monitor_mask) >> (cr * 2)) & mode) != 0;
++}
++
++static inline int kvm_is_mem_event_enabled(struct kvm *kvm)
++{
++	return kvm->mem_event_enabled;
++}
++
++void kvm_deliver_cr_read_event(struct kvm_vcpu *vcpu, int cr, u64 val);
++void kvm_deliver_cr_write_event(struct kvm_vcpu *vcpu, int cr, u64 val);
++void kvm_deliver_syscall_event(struct kvm_vcpu *vcpu, u64 return_address);
++void kvm_deliver_sysenter_event(struct kvm_vcpu *vcpu, u64 return_address);
++void kvm_deliver_sysret_event(struct kvm_vcpu *vcpu);
++void kvm_deliver_sysexit_event(struct kvm_vcpu *vcpu);
++void kvm_deliver_vmcall_event(struct kvm_vcpu *vcpu);
++void kvm_deliver_trap_event(struct kvm_vcpu *vcpu, int vector);
++void kvm_deliver_invlpg_event(struct kvm_vcpu *vcpu, u64 gva);
++void kvm_deliver_monitor_trap_flag_event(struct kvm_vcpu *vcpu);
++void kvm_deliver_reboot_event(struct kvm_vcpu *vcpu);
++void kvm_deliver_mem_event(struct kvm_vcpu *vcpu, u64 gpa, u32 error_code);
++
+ extern u64 host_xcr0;
+ extern u64 host_xss;
+ extern u64 host_arch_capabilities;
+Index: 6.8.0-41-generic/kernel/include/linux/kvm_host.h
+===================================================================
+--- 6.8.0-41-generic.orig/kernel/include/linux/kvm_host.h
++++ 6.8.0-41-generic/kernel/include/linux/kvm_host.h
+@@ -28,6 +28,7 @@
+ #include <linux/rcuwait.h>
+ #include <linux/refcount.h>
+ #include <linux/nospec.h>
++#include <linux/hashtable.h>
+ #include <linux/notifier.h>
+ #include <linux/ftrace.h>
+ #include <linux/hashtable.h>
+@@ -380,6 +381,26 @@ struct kvm_vcpu {
+ #endif
+ 	bool preempted;
+ 	bool ready;
++
++	/* Introspection */
++	wait_queue_head_t introspection_wait_queue;
++	wait_queue_head_t introspection_event_completed_wait_queue;
++	struct mutex introspection_event_mutex;
++	struct kvm_introspection_event* introspection_event;
++	bool introspection_event_pending_completion;
++	u32 cr_monitor_mask;
++	bool invlpg_hook;
++	bool syscall_hook_enabled;
++	u64 shadow_msr_ia32_sysenter_cs;
++	bool vmcall_hook_enabled;
++	struct mm_struct *introspection_mm;
++	bool reboot_pending;
++	bool monitor_trap_flag;
++	u64 tid_address;
++
++	wait_queue_head_t pause_wait_queue;
++	atomic_t pause_count;
++
+ 	struct kvm_vcpu_arch arch;
+ 	struct kvm_vcpu_stat stat;
+ 	char stats_id[KVM_STATS_NAME_SIZE];
+@@ -730,6 +751,17 @@ struct kvm_memslots {
+ 	int node_idx;
+ };
+ 
++struct mem_access_entry {
++	struct hlist_node node;
++	u64 gfn;
++	uint8_t original_perms;
++};
++
++struct mem_access_table {
++	DECLARE_HASHTABLE(table, 4);
++	struct mutex mutex;
++};
++
+ struct kvm {
+ #ifdef KVM_HAVE_MMU_RWLOCK
+ 	rwlock_t mmu_lock;
+@@ -840,6 +872,12 @@ struct kvm {
+ 	struct xarray mem_attr_array;
+ #endif
+ 	char stats_id[KVM_STATS_NAME_SIZE];
++
++	/* IntroVirt introspection patch */
++	struct mem_access_table mem_access_table;
++	atomic64_t event_id;
++	struct mm_struct *introspection_mm;
++	bool mem_event_enabled;
+ };
+ 
+ #define kvm_err(fmt, ...) \
+@@ -985,6 +1023,9 @@ void kvm_destroy_vcpus(struct kvm *kvm);
+ void vcpu_load(struct kvm_vcpu *vcpu);
+ void vcpu_put(struct kvm_vcpu *vcpu);
+ 
++void kvm_vcpu_pause(struct kvm_vcpu *vcpu);
++void kvm_vcpu_unpause(struct kvm_vcpu *vcpu);
++
+ #ifdef __KVM_HAVE_IOAPIC
+ void kvm_arch_post_irq_ack_notifier_list_update(struct kvm *kvm);
+ void kvm_arch_post_irq_routing_update(struct kvm *kvm);
+@@ -1408,8 +1449,11 @@ void kvm_arch_vcpu_blocking(struct kvm_v
+ void kvm_arch_vcpu_unblocking(struct kvm_vcpu *vcpu);
+ bool kvm_vcpu_wake_up(struct kvm_vcpu *vcpu);
+ void kvm_vcpu_kick(struct kvm_vcpu *vcpu);
++void kvm_arch_introspection_cleanup(struct kvm_vcpu *vcpu);
++void kvm_deliver_shutdown_event(struct kvm_vcpu *vcpu);
+ int kvm_vcpu_yield_to(struct kvm_vcpu *target);
+ void kvm_vcpu_on_spin(struct kvm_vcpu *vcpu, bool yield_to_kernel_mode);
++void kvm_vcpu_check_pause(struct kvm_vcpu *vcpu); /* IntroVirt addition */
+ 
+ void kvm_flush_remote_tlbs(struct kvm *kvm);
+ void kvm_flush_remote_tlbs_range(struct kvm *kvm, gfn_t gfn, u64 nr_pages);
+Index: 6.8.0-41-generic/kernel/include/uapi/linux/kvm.h
+===================================================================
+--- 6.8.0-41-generic.orig/kernel/include/uapi/linux/kvm.h
++++ 6.8.0-41-generic/kernel/include/uapi/linux/kvm.h
+@@ -536,6 +536,20 @@ struct kvm_translation {
+ 	__u8  pad[5];
+ };
+ 
++/* for KVM_TRANSLATE_DTB */
++struct kvm_translation_dtb {
++	/* in */
++	__u64 linear_address;
++	__u64 directory_table_base;
++
++	/* out */
++	__u64 physical_address;
++	__u8  valid;
++	__u8  writeable;
++	__u8  usermode;
++	__u8  pad[5];
++};
++
+ /* for KVM_S390_MEM_OP */
+ struct kvm_s390_mem_op {
+ 	/* in */
+@@ -901,6 +915,133 @@ struct kvm_ppc_resize_hpt {
+ #define KVM_GET_MSR_FEATURE_INDEX_LIST    _IOWR(KVMIO, 0x0a, struct kvm_msr_list)
+ 
+ /*
++ * Introspection API (KVM_CAP_INTROSPECTION)
++ */
++
++//
++// structs
++//
++struct kvm_introspection_patch_ver {
++    char buffer[64];
++};
++
++struct kvm_inject_trap {
++    __u32 vector;
++    __u32 error_code;
++    __u64 cr2;
++    int has_error;
++};
++
++struct kvm_ept_permissions {
++    __u64 gfn;
++    __u8 perms : 3;
++};
++
++struct kvm_cr_monitor {
++	int cr;
++	int mode; // Bitmask of KVM_MONITOR_CR_[READ/WRITE]
++};
++
++struct kvm_introspection_event {
++    __u64 event_id; // Increments with each event
++    int event_type; // KVM_EVENT_TYPE_
++    int vcpu_id;    // The ID of the VCPU that triggered the event
++
++    // Registers
++    struct kvm_regs regs;
++    struct kvm_sregs sregs;
++    struct kvm_debugregs debugregs;
++
++    union {
++        struct {
++            int cr;			// 0-8
++			int mode;		// KVM_MONITOR_CR_[READ/WRITE]
++            __u64 value;	// Value being loaded/stored
++        } cr_access;
++        struct {
++            int type; 	// KVM_EVENT_SYSTEM_CALL_TYPE_[X]
++            __u64 return_address;
++        } system_call;
++        struct {
++            int type;	// KVM_EVENT_SYSTEM_CALL_RET_TYPE_[X]
++			__u64 thread_id; // The address of the kernel stack base for this thread (or 0 if not available)
++        } system_call_ret;
++        struct {
++            int vector; // The vector that caused the trap, e.g. BP_VECTOR
++        } trap;
++		struct {
++			__u64 gpa;
++			__u32 error_code;
++		} mem_event;
++		struct {
++			__u64 gva;
++		} invlpg;
++    };
++};
++
++//
++// constants
++//
++#define KVM_EVENT_FAST_SYSCALL 0     // A system call event
++#define KVM_EVENT_FAST_SYSCALL_RET 1 // A system call return event
++#define KVM_EVENT_SW_INT 2           // A software interrupt event
++#define KVM_EVENT_SW_IRET 3          // A software interrupt return event
++#define KVM_EVENT_CR_READ 4          // A control register was read
++#define KVM_EVENT_CR_WRITE 5         // A control register was written to
++#define KVM_EVENT_MSR_READ 6         // An MSR was read
++#define KVM_EVENT_MSR_WRITE 7        // An MSR was written to
++#define KVM_EVENT_EXCEPTION 8        // An x86 exception event
++#define KVM_EVENT_MEM_ACCESS 9       // Hardware assisted paging violation (memory breakpoints)
++#define KVM_EVENT_SINGLE_STEP 10     // Single step event
++#define KVM_EVENT_HYPERCALL 11       // An intercepted hypercall
++#define KVM_EVENT_REBOOT 12          // The guest VM has rebooted
++#define KVM_EVENT_SHUTDOWN 13        // The guest VM has shutdown
++#define KVM_EVENT_INVLPG 14          // INVLPG instruction was executed
++
++#define KVM_EVENT_SYSTEM_CALL_TYPE_SYSCALL	1
++#define KVM_EVENT_SYSTEM_CALL_TYPE_SYSENTER	2
++
++#define KVM_EVENT_SYSTEM_CALL_RET_TYPE_SYSRET	1
++#define KVM_EVENT_SYSTEM_CALL_RET_TYPE_SYSEXIT	2
++
++#define KVM_MONITOR_CR_READ      (1u << 0)
++#define KVM_MONITOR_CR_WRITE     (1u << 1)
++
++#define KVM_CAP_INTROSPECTION 20150308
++#define KVM_INTROSPECTION_API_VERSION 5
++
++#ifndef KVM_INTROSPECTION_PATCH_VERSION
++#define KVM_INTROSPECTION_PATCH_VERSION "UNKNOWN_INTROVIRT_VERSION"
++#endif
++
++//
++// ioctls
++//
++
++// kvm dev level
++#define KVM_ATTACH_VM _IOW(KVMIO, 0xd0, pid_t)
++#define KVM_GET_INTROSPECTION_PATCH_VERSION _IOR(KVMIO, 0xd1, struct kvm_introspection_patch_ver)
++
++// VM Level
++#define KVM_ATTACH_VCPU _IOW(KVMIO, 0xd2, unsigned long)
++#define KVM_SET_MEM_ACCESS_ENABLED _IOW(KVMIO, 0xd4, unsigned long)
++#define KVM_SET_MEM_ACCESS _IOW(KVMIO, 0xd5, struct kvm_ept_permissions)
++
++// VCPU level
++#define KVM_SET_CR_MONITOR _IOW(KVMIO, 0xd6, struct kvm_cr_monitor)
++#define KVM_SET_SYSCALL_HOOK _IOW(KVMIO, 0xd7, unsigned long)
++#define KVM_SET_VMCALL_HOOK _IOW(KVMIO, 0xd8, unsigned long)
++#define KVM_VCPU_PAUSE _IO(KVMIO, 0xd9)
++#define KVM_VCPU_UNPAUSE _IO(KVMIO, 0xda)
++#define KVM_GET_INTROSPECTION_EVENT _IOR(KVMIO, 0xdb, struct kvm_introspection_event)
++#define KVM_COMPLETE_INTROSPECTION_EVENT _IO(KVMIO, 0xdc)
++#define KVM_INJECT_TRAP _IOW(KVMIO, 0xdd, struct kvm_inject_trap)
++#define KVM_SET_MONITOR_TRAP_FLAG _IOW(KVMIO, 0xde, unsigned long)
++#define KVM_SET_INVLPG_HOOK _IOW(KVMIO, 0xdf, unsigned long)
++#define KVM_VCPU_INJECT_SYSCALL _IO(KVMIO, 0xf1)
++#define KVM_VCPU_INJECT_SYSENTER _IO(KVMIO, 0xf2)
++
++/*
+  * Extension capability list.
+  */
+ #define KVM_CAP_IRQCHIP	  0
+Index: 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
+===================================================================
+--- 6.8.0-41-generic.orig/kernel/virt/kvm/kvm_main.c
++++ 6.8.0-41-generic/kernel/virt/kvm/kvm_main.c
+@@ -501,6 +501,14 @@ static void kvm_vcpu_init(struct kvm_vcp
+ 	/* Fill the stats id string for the vcpu */
+ 	snprintf(vcpu->stats_id, sizeof(vcpu->stats_id), "kvm-%d/vcpu-%d",
+ 		 task_pid_nr(current), id);
++
++	/* IntroVirt introspection patch */
++	mutex_init(&vcpu->introspection_event_mutex);
++	init_waitqueue_head(&vcpu->introspection_event_completed_wait_queue);
++	init_waitqueue_head(&vcpu->introspection_wait_queue);
++	init_waitqueue_head(&vcpu->pause_wait_queue);
++	vcpu->introspection_event = NULL;
++	vcpu->reboot_pending = false;
+ }
+ 
+ static void kvm_vcpu_destroy(struct kvm_vcpu *vcpu)
+@@ -1295,6 +1303,9 @@ static struct kvm *kvm_create_vm(unsigne
+ 	preempt_notifier_inc();
+ 	kvm_init_pm_notifier(kvm);
+ 
++	mutex_init(&kvm->mem_access_table.mutex);
++	hash_init(kvm->mem_access_table.table);
++
+ 	return kvm;
+ 
+ out_err:
+@@ -1446,6 +1457,18 @@ static int kvm_vm_release(struct inode *
+ 	return 0;
+ }
+ 
++static int kvm_vm_introvirt_release(struct inode *inode, struct file *filp)
++{
++    struct kvm *kvm = filp->private_data;
++
++    // IntroVirt tool detaching
++
++    kvm->introspection_mm = NULL;
++
++    kvm_put_kvm(kvm);
++    return 0;
++}
++
+ /*
+  * Allocation size is twice as large as the actual dirty bitmap size.
+  * See kvm_vm_ioctl_get_dirty_log() why this is needed.
+@@ -3773,6 +3796,9 @@ bool kvm_vcpu_block(struct kvm_vcpu *vcp
+ 		if (kvm_vcpu_check_block(vcpu) < 0)
+ 			break;
+ 
++		if (unlikely(atomic_read(&vcpu->pause_count) > 0))
++			break;
++
+ 		waited = true;
+ 		schedule();
+ 	}
+@@ -4162,16 +4188,81 @@ static int kvm_vcpu_release(struct inode
+ {
+ 	struct kvm_vcpu *vcpu = filp->private_data;
+ 
++	if (vcpu->vcpu_id == 0)
++		kvm_deliver_shutdown_event(vcpu);
++
+ 	kvm_put_kvm(vcpu->kvm);
+ 	return 0;
+ }
+ 
++
++static int kvm_vcpu_introvirt_release(struct inode *inode, struct file *filp)
++{
++	struct kvm_vcpu *vcpu = filp->private_data;
++
++	kvm_vcpu_pause(vcpu);
++
++	mutex_lock(&vcpu->mutex);
++	vcpu_load(vcpu);
++
++	// Turn off introspection features
++	kvm_arch_introspection_cleanup(vcpu);
++
++	vcpu->introspection_event = NULL;
++	vcpu->introspection_event_pending_completion = false;
++	vcpu->introspection_mm = NULL;
++
++	// Resume the VCPU
++	vcpu_put(vcpu);
++	mutex_unlock(&vcpu->mutex);
++
++	// Wake up anyone that's paused
++	atomic_set(&vcpu->pause_count, 0);
++	wake_up_all(&vcpu->pause_wait_queue);
++
++	// If an introspection event is being delivered, wake that up
++	wake_up(&vcpu->introspection_event_completed_wait_queue);
++
++	kvm_put_kvm(vcpu->kvm);
++
++	return 0;
++}
++
++// Poll for introspection events
++static unsigned int kvm_vcpu_poll(struct file *filp, poll_table *wait)
++{
++	struct kvm_vcpu* vcpu = filp->private_data;
++	unsigned int mask = 0;
++
++	poll_wait(filp, &vcpu->introspection_wait_queue, wait);
++
++	if(mutex_lock_interruptible(&vcpu->introspection_event_mutex))
++		return -ERESTARTSYS;
++
++	if(vcpu->introspection_event != NULL)
++		mask |= POLLIN;
++
++	mutex_unlock(&vcpu->introspection_event_mutex);
++
++	return mask;
++}
++
+ static struct file_operations kvm_vcpu_fops = {
+ 	.release        = kvm_vcpu_release,
+ 	.unlocked_ioctl = kvm_vcpu_ioctl,
+ 	.mmap           = kvm_vcpu_mmap,
+ 	.llseek		= noop_llseek,
+ 	KVM_COMPAT(kvm_vcpu_compat_ioctl),
++	.poll		= kvm_vcpu_poll,
++};
++
++static struct file_operations kvm_vcpu_introvirt_fops = {
++    .release        = kvm_vcpu_introvirt_release,
++    .unlocked_ioctl = kvm_vcpu_ioctl,
++    .mmap           = kvm_vcpu_mmap,
++    .llseek     = noop_llseek,
++    KVM_COMPAT(kvm_vcpu_compat_ioctl),
++    .poll       = kvm_vcpu_poll,
+ };
+ 
+ /*
+@@ -4198,6 +4289,11 @@ static int vcpu_get_pid(void *data, u64
+ 
+ DEFINE_SIMPLE_ATTRIBUTE(vcpu_get_pid_fops, vcpu_get_pid, NULL, "%llu\n");
+ 
++static int create_vcpu_introvirt_fd(struct kvm_vcpu *vcpu)
++{
++    return anon_inode_getfd("kvm-vcpu", &kvm_vcpu_introvirt_fops, vcpu, O_RDWR | O_CLOEXEC);
++}
++
+ static void kvm_create_vcpu_debugfs(struct kvm_vcpu *vcpu)
+ {
+ 	struct dentry *debugfs_dentry;
+@@ -4330,6 +4426,35 @@ vcpu_decrement:
+ 	return r;
+ }
+ 
++/* Attach for introspection */
++static int kvm_vm_ioctl_attach_vcpu(struct kvm *kvm, u32 id) {
++	struct kvm_vcpu* vcpu;
++	int r;
++
++	kvm_get_kvm(kvm);
++
++	r = -ESRCH;
++	vcpu = kvm_get_vcpu_by_id(kvm, id);
++	if(!vcpu)
++		goto out_err;
++
++	r = -EBUSY;
++	if (vcpu->introspection_mm)
++		goto out_err;
++
++	r = create_vcpu_introvirt_fd(vcpu);
++	if(r < 0)
++		goto out_err;
++
++	vcpu->introspection_mm = current->mm;
++	goto out;
++
++out_err:
++	kvm_put_kvm(kvm);
++out:
++	return r;
++}
++
+ static int kvm_vcpu_ioctl_set_sigmask(struct kvm_vcpu *vcpu, sigset_t *sigset)
+ {
+ 	if (sigset) {
+@@ -4392,6 +4517,31 @@ static int kvm_vcpu_ioctl_get_stats_fd(s
+ 	return fd;
+ }
+ 
++void kvm_vcpu_pause(struct kvm_vcpu *vcpu)
++{
++	if (atomic_inc_return(&vcpu->pause_count) == 1) {
++		/*
++		 * Wake up the vcpu
++		 */
++		kvm_vcpu_kick(vcpu);
++
++		/*
++		 * Wait for the vcpu to pause
++		 */
++		if (mutex_lock_killable(&vcpu->mutex)) {
++			return;
++		}
++		mutex_unlock(&vcpu->mutex);
++	}
++}
++
++void kvm_vcpu_unpause(struct kvm_vcpu *vcpu)
++{
++	if(atomic_dec_and_test(&vcpu->pause_count)) {
++		wake_up_all(&vcpu->pause_wait_queue);
++	}
++}
++
+ static long kvm_vcpu_ioctl(struct file *filp,
+ 			   unsigned int ioctl, unsigned long arg)
+ {
+@@ -4401,8 +4551,8 @@ static long kvm_vcpu_ioctl(struct file *
+ 	struct kvm_fpu *fpu = NULL;
+ 	struct kvm_sregs *kvm_sregs = NULL;
+ 
+-	if (vcpu->kvm->mm != current->mm || vcpu->kvm->vm_dead)
+-		return -EIO;
++	/*if (vcpu->kvm->mm != current->mm || vcpu->kvm->vm_dead)
++		return -EIO;*/
+ 
+ 	if (unlikely(_IOC_TYPE(ioctl) != KVMIO))
+ 		return -EINVAL;
+@@ -4415,6 +4565,69 @@ static long kvm_vcpu_ioctl(struct file *
+ 	if (r != -ENOIOCTLCMD)
+ 		return r;
+ 
++	// IOCTLs that take place without locking vcpu->mutex
++	switch (ioctl) {
++	case KVM_VCPU_PAUSE: {
++		r = 0;
++		kvm_vcpu_pause(vcpu);
++		return r;
++	}
++	case KVM_VCPU_UNPAUSE: {
++		r = 0;
++		kvm_vcpu_unpause(vcpu);
++		return r;
++	}
++	case KVM_GET_INTROSPECTION_EVENT: {
++		if(mutex_lock_interruptible(&vcpu->introspection_event_mutex))
++			return -ERESTARTSYS;
++
++		r = -ENOENT;
++		if(vcpu->introspection_event) {
++			r = -EFAULT;
++			if(!copy_to_user(argp, vcpu->introspection_event,
++					sizeof(struct kvm_introspection_event))) {
++				r = 0;
++				vcpu->introspection_event = NULL;
++			}
++		}
++
++		mutex_unlock(&vcpu->introspection_event_mutex);
++		return r;
++	}
++	case KVM_COMPLETE_INTROSPECTION_EVENT: {
++		if(mutex_lock_interruptible(&vcpu->introspection_event_mutex))
++			return -ERESTARTSYS;
++
++		r = -EINVAL;
++		if(vcpu->introspection_event_pending_completion) {
++			vcpu->introspection_event_pending_completion = false;
++			r = 0;
++
++			// Wake up the VCPU
++			wake_up(&vcpu->introspection_event_completed_wait_queue);
++		}
++
++		mutex_unlock(&vcpu->introspection_event_mutex);
++
++		return r;
++	}
++	}
++
++	/*
++	 * Block Qemu while we're paused.
++	 *
++	 * This almost never happens. Qemu would have
++	 * to be in userland while a kvm_vcpu_pause()
++	 * is issued. Normally we kick it and pause after
++	 * it wakes.
++	 */
++	if (unlikely(vcpu->kvm->mm == current->mm
++		&& atomic_read(&vcpu->pause_count))) {
++			/* Wait until we're resumed */
++			wait_event(vcpu->pause_wait_queue,
++				atomic_read(&vcpu->pause_count) == 0);
++	}
++
+ 	if (mutex_lock_killable(&vcpu->mutex))
+ 		return -EINTR;
+ 	switch (ioctl) {
+@@ -5096,8 +5309,8 @@ static long kvm_vm_ioctl(struct file *fi
+ 	void __user *argp = (void __user *)arg;
+ 	int r;
+ 
+-	if (kvm->mm != current->mm || kvm->vm_dead)
+-		return -EIO;
++	/*if (kvm->mm != current->mm || kvm->vm_dead)
++		return -EIO;*/
+ 	switch (ioctl) {
+ 	case KVM_CREATE_VCPU:
+ 		r = kvm_vm_ioctl_create_vcpu(kvm, arg);
+@@ -5321,6 +5534,9 @@ static long kvm_vm_ioctl(struct file *fi
+ 		break;
+ 	}
+ #endif
++	case KVM_ATTACH_VCPU:
++		r = kvm_vm_ioctl_attach_vcpu(kvm, arg);
++		break;
+ 	default:
+ 		r = kvm_arch_vm_ioctl(filp, ioctl, arg);
+ 	}
+@@ -5408,11 +5624,99 @@ static long kvm_vm_compat_ioctl(struct f
+ }
+ #endif
+ 
++static void kvm_vm_munmap(struct vm_area_struct *vma) {
++	struct page* page = vma->vm_private_data;
++	put_page(page);
++}
++
++static struct vm_operations_struct kvm_vm_mapping_ops = {
++    .close        = kvm_vm_munmap,
++};
++
++static int kvm_vm_mmap(struct file *filp, struct vm_area_struct *vma)
++{
++	struct kvm *kvm = vma->vm_file->private_data;
++	const gfn_t first_page = vma->vm_start >> PAGE_SHIFT;
++	const gfn_t last_page = (vma->vm_end - 1) >> PAGE_SHIFT;
++	const unsigned int page_count = (last_page - first_page) + 1;
++	unsigned long addresses[16];
++	struct page* pages[16];
++	int i;
++
++	vma->vm_ops = &kvm_vm_mapping_ops;
++
++	if ( page_count > 1 ) {
++		return -E2BIG;
++	}
++
++	/*
++	 * Translate each guest gfn to an address
++	 */
++	for(i = 0; i < page_count; ++i) {
++		gfn_t gfn = vma->vm_pgoff + i;
++		uint64_t addr = gfn_to_hva(kvm, gfn);
++		if(kvm_is_error_hva(addr)) {
++			if(addr == KVM_HVA_ERR_BAD) {
++				return -EFAULT;
++			} else if(addr == KVM_HVA_ERR_RO_BAD) {
++				return -EPERM;
++			} else {
++				return -EINVAL;
++			}
++		}
++		addresses[i] = addr;
++	}
++
++	/*
++	 * Translate each address to page structs
++	 */
++	down_read(&kvm->mm->mmap_lock);
++	for(i = 0; i < page_count; ++i) {
++		int npages;
++		npages = get_user_pages_remote(kvm->mm, addresses[i], 1, FOLL_WRITE,
++				&pages[i], NULL);
++
++		if(unlikely(npages != 1)) {
++			up_read(&kvm->mm->mmap_lock);
++			return VM_FAULT_SIGBUS;
++		}
++	}
++	up_read(&kvm->mm->mmap_lock);
++
++	/*
++	 * Do the actual mapping
++	 */
++	down_write(&kvm->mm->mmap_lock);
++	for(i = 0; i < page_count; ++i) {
++		int r;
++
++		r = remap_pfn_range(vma, vma->vm_start + (0x1000 * i),
++				page_to_pfn(pages[i]), 0x1000,
++				vma->vm_page_prot);
++		if(r)
++			printk(KERN_ALERT "vm_insert_page() failed : %d\n", r);
++
++		vma->vm_private_data = pages[i];
++	}
++	up_write(&kvm->mm->mmap_lock);
++
++	return 0;
++}
++
+ static struct file_operations kvm_vm_fops = {
+ 	.release        = kvm_vm_release,
+ 	.unlocked_ioctl = kvm_vm_ioctl,
+ 	.llseek		= noop_llseek,
+ 	KVM_COMPAT(kvm_vm_compat_ioctl),
++	.mmap           = kvm_vm_mmap,
++};
++
++static struct file_operations kvm_vm_introvirt_fops = {
++    .release        = kvm_vm_introvirt_release,
++    .unlocked_ioctl = kvm_vm_ioctl,
++	KVM_COMPAT(kvm_vm_compat_ioctl),
++    .llseek     = noop_llseek,
++    .mmap           = kvm_vm_mmap,
+ };
+ 
+ bool file_is_kvm(struct file *file)
+@@ -5464,10 +5768,39 @@ put_fd:
+ 	return r;
+ }
+ 
++/*
++ * Find a VM based on the PID
++ */
++static struct kvm* get_vm_by_pid(pid_t pid)
++{
++	struct kvm *rv;
++	struct kvm *kvm;
++
++	rv = NULL;
++
++	mutex_lock(&kvm_lock);
++	list_for_each_entry(kvm, &vm_list, vm_list)
++	{
++		if(kvm->mm && kvm->mm->owner)
++		{
++			if(kvm->mm->owner->pid == pid)
++			{
++				rv = kvm;
++				break;
++			}
++		}
++	}
++
++	mutex_unlock(&kvm_lock);
++
++	return rv;
++}
++
+ static long kvm_dev_ioctl(struct file *filp,
+ 			  unsigned int ioctl, unsigned long arg)
+ {
+ 	int r = -EINVAL;
++	void __user *argp = (void __user *)arg;
+ 
+ 	switch (ioctl) {
+ 	case KVM_GET_API_VERSION:
+@@ -5492,6 +5825,48 @@ static long kvm_dev_ioctl(struct file *f
+ 		r += PAGE_SIZE;    /* coalesced mmio ring page */
+ #endif
+ 		break;
++	case KVM_ATTACH_VM: {
++		struct kvm* kvm;
++
++		r = -ESRCH;
++		kvm = get_vm_by_pid(arg);
++		if(!kvm)
++			goto out;
++
++		r = -EBUSY;
++		if(kvm->introspection_mm)
++		    goto out;
++
++		/* Increment the counter */
++		kvm_get_kvm(kvm);
++
++		/* Get handle to the VM */
++		r = anon_inode_getfd("kvm-vm", &kvm_vm_introvirt_fops, kvm,
++				O_RDWR | O_CLOEXEC);
++
++		kvm->introspection_mm = current->mm;
++
++		if(r < 0) {
++			kvm_put_kvm(kvm);
++			kvm->introspection_mm = NULL;
++		}
++		break;
++	}
++	case KVM_GET_INTROSPECTION_PATCH_VERSION: {
++		const char* str = KVM_INTROSPECTION_PATCH_VERSION;
++		const int len = strlen(str) + 1;
++
++		if (len > sizeof(struct kvm_introspection_patch_ver)) {
++			r = -ETOOSMALL;
++			goto out;
++		}
++
++		r = -EFAULT;
++		if(!copy_to_user(argp, str, len)) {
++			r = 0;
++		}
++		break;
++	}
+ 	default:
+ 		return kvm_arch_dev_ioctl(filp, ioctl, arg);
+ 	}
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/mmu/mmu.c
+===================================================================
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/mmu/mmu.c
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/mmu/mmu.c
+@@ -4596,6 +4596,37 @@ int kvm_tdp_page_fault(struct kvm_vcpu *
+ 		}
+ 	}
+ 
++	/* If IntroVirt is hooking EPT faults, deliver here */
++	if (fault->guest_initiated && kvm_is_mem_event_enabled(vcpu->kvm))
++	{
++		/* Look up the fault */
++		struct kvm *kvm = vcpu->kvm;
++		struct mem_access_entry *entry;
++		const u64 gfn = fault->gfn;
++		bool found_match = false;
++
++		mutex_lock(&kvm->mem_access_table.mutex);
++
++		/* Search for the entry */
++		hash_for_each_possible(kvm->mem_access_table.table, entry, node, gfn)
++		{
++			/* Found a match, check requested permission */
++			if(entry->gfn == gfn) {
++				/* Match! */
++				found_match = true;
++				break;
++			}
++		}
++		mutex_unlock(&kvm->mem_access_table.mutex);
++
++		/* If we found a match, deliver it */
++		if (found_match) {
++			printk(KERN_DEBUG "IV-mmu: Matched EPT fault mem event for gfn 0x%08llx. Code: %d\n", gfn, fault->error_code);
++			kvm_deliver_mem_event(vcpu, fault->addr, fault->error_code);
++			return RET_PF_RETRY;
++		}
++	}
++
+ #ifdef CONFIG_X86_64
+ 	if (tdp_mmu_enabled)
+ 		return kvm_tdp_mmu_page_fault(vcpu, fault);
+@@ -4604,6 +4635,71 @@ int kvm_tdp_page_fault(struct kvm_vcpu *
+ 	return direct_page_fault(vcpu, fault);
+ }
+ 
++static int kvm_tdp_set_pte_perms(struct kvm_vcpu *vcpu, u64 gfn, uint8_t perms, uint8_t* original_perms)
++{
++	struct kvm_shadow_walk_iterator iterator;
++	int result = -ESRCH;
++	u64 gpa = gfn << PAGE_SHIFT;
++	u64 spte = 0ull;
++
++	// Turn off any extra bits in the perms
++	perms &= (PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK);
++
++	// Validate the HAP permissions are allowed
++	if (unlikely(!kvm_x86_ops.hap_permissions_allowed(perms)))
++		return -EINVAL;
++
++	if (!VALID_PAGE(vcpu->arch.mmu->root.hpa))
++	{
++		result = kvm_mmu_load(vcpu);
++		if (unlikely(result))
++			return result;
++	}
++
++retry:
++	walk_shadow_page_lockless_begin(vcpu);
++
++	/* Find the page in the shadow tables */
++	for_each_shadow_entry_lockless(vcpu, gpa, iterator, spte)
++		if (!is_shadow_present_pte(spte) ||
++			iterator.level < PG_LEVEL_4K)
++				{
++					/* The page is not present, so page it in for the guest process */
++					struct mm_struct* mm;
++					int r;
++
++					walk_shadow_page_lockless_end(vcpu);
++
++					/* Dirty hack */
++					/* hva_to_pfn() is hard-coded to current->mm */
++					mm = current->mm;
++					current->mm = vcpu->kvm->mm;
++					r = __kvm_mmu_do_page_fault(vcpu, gpa, 0, false, NULL, false);
++					current->mm = mm;
++					if (r)
++						return r;
++					goto retry;
++				}
++
++	// Try a few times to update the pte
++	result = -EBUSY;
++	do {
++		u64 new_spte = (spte & ~(PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK)) | perms;
++
++		if (original_perms != NULL)
++			*original_perms = (spte & (PT_USER_MASK|PT_WRITABLE_MASK|PT_PRESENT_MASK));
++
++		if (cmpxchg64(iterator.sptep, spte, new_spte) == spte)
++		{
++			result = 0;
++			break;
++		}
++	} while(true);
++
++	walk_shadow_page_lockless_end(vcpu);
++	return result;
++}
++
+ static void nonpaging_init_context(struct kvm_mmu *context)
+ {
+ 	context->page_fault = nonpaging_page_fault;
+@@ -5299,6 +5395,7 @@ static void init_kvm_tdp_mmu(struct kvm_
+ 	context->cpu_role.as_u64 = cpu_role.as_u64;
+ 	context->root_role.word = root_role.word;
+ 	context->page_fault = kvm_tdp_page_fault;
++	context->set_pte_perms = kvm_tdp_set_pte_perms;
+ 	context->sync_spte = NULL;
+ 	context->get_guest_pgd = get_guest_cr3;
+ 	context->get_pdptr = kvm_pdptr_read;
+Index: 6.8.0-41-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
+===================================================================
+--- 6.8.0-41-generic.orig/kernel/arch/x86/kvm/mmu/mmu_internal.h
++++ 6.8.0-41-generic/kernel/arch/x86/kvm/mmu/mmu_internal.h
+@@ -247,6 +247,11 @@ struct kvm_page_fault {
+ 	 * is changing its own translation in the guest page tables.
+ 	 */
+ 	bool write_fault_to_shadow_pgtable;
++
++	/*
++	 * IntroVirt Patch
++	 */
++	bool guest_initiated;
+ };
+ 
+ int kvm_tdp_page_fault(struct kvm_vcpu *vcpu, struct kvm_page_fault *fault);
+@@ -279,8 +284,8 @@ enum {
+ 	RET_PF_SPURIOUS,
+ };
+ 
+-static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
+-					u32 err, bool prefetch, int *emulation_type)
++static inline int __kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
++					u32 err, bool prefetch, int *emulation_type, bool guest_initiated)
+ {
+ 	struct kvm_page_fault fault = {
+ 		.addr = cr2_or_gpa,
+@@ -299,6 +304,11 @@ static inline int kvm_mmu_do_page_fault(
+ 		.req_level = PG_LEVEL_4K,
+ 		.goal_level = PG_LEVEL_4K,
+ 		.is_private = kvm_mem_is_private(vcpu->kvm, cr2_or_gpa >> PAGE_SHIFT),
++
++		/*
++		 * IntroVirt Patch
++		 */
++		.guest_initiated = guest_initiated,
+ 	};
+ 	int r;
+ 
+@@ -339,6 +349,12 @@ static inline int kvm_mmu_do_page_fault(
+ 	return r;
+ }
+ 
++static inline int kvm_mmu_do_page_fault(struct kvm_vcpu *vcpu, gpa_t cr2_or_gpa,
++					u32 err, bool prefetch, int *emulation_type)
++{
++	return __kvm_mmu_do_page_fault(vcpu, cr2_or_gpa, err, prefetch, emulation_type, 1);
++}
++
+ int kvm_mmu_max_mapping_level(struct kvm *kvm,
+ 			      const struct kvm_memory_slot *slot, gfn_t gfn,
+ 			      int max_level);

--- a/ubuntu/noble/hwe/6.8.0-90-generic/patches/series
+++ b/ubuntu/noble/hwe/6.8.0-90-generic/patches/series
@@ -1,0 +1,1 @@
+kvm-introvirt-hwe-6.8.0-90-generic


### PR DESCRIPTION
closes #16 
closes #17 

This addresses issues with hypercall handling and memory watchpoints in the patch from the transition from the 5.X to 6.X kernel. 