### PR TITLE
Initial/Fix amd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI Tests](https://github.com/IntroVirt/kvm-introvirt/actions/workflows/ci.yml/badge.svg)](https://github.com/IntroVirt/kvm-introvirt/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-IntroVirt KVM module. Intel CPUs have full support. AMD CPUs are lacking support for breakpoints but syscall tracing should work.
+IntroVirt KVM module. Intel CPUs have full support. AMD CPUs are lacking support for breakpoints/watchpoints but system call tracing works.
 
 ## Installation Instructions
 

--- a/scripts/debug-kvm-patch.sh
+++ b/scripts/debug-kvm-patch.sh
@@ -3,9 +3,17 @@
 # Helper to build and insert modified KVM kernel module for debugging
 # Run from the root of the repo
 
-if [[ $# -ne 2 ]]; then
-    echo "Usage: $0 <path-to-kernel-source> <path-to-signing-key-dir>"
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <path-to-kernel-source> [path-to-signing-key-dir]"
     exit 1
+fi
+
+KERNEL_SRC=$1
+
+if [[ $# -ne 2 ]]; then
+    SIGNING_KEY_DIR=""
+else
+    SIGNING_KEY_DIR=$2
 fi
 
 if [[ $EUID -ne 0 ]]; then
@@ -21,17 +29,23 @@ fi
 _KVM_INTROVIRT_TRACE_EVENTS=${KVM_INTROVIRT_TRACE_EVENTS:=0}
 echo "KVM introspection trace events level: ${_KVM_INTROVIRT_TRACE_EVENTS}"
 
-KERNEL_SRC=$1
-SIGNING_KEY_DIR=$2
-
 if [[ ! -d "${KERNEL_SRC}" ]]; then
     echo "Kernel source directory ${KERNEL_SRC} does not exist!"
     exit 1
 fi
 
-if [[ ! -d "${SIGNING_KEY_DIR}" ]]; then
+if [[ -n "${SIGNING_KEY_DIR}" && ! -d "${SIGNING_KEY_DIR}" ]]; then
     echo "Signing key directory ${SIGNING_KEY_DIR} does not exist!"
     exit 1
+else
+    echo "No signing key directory provided, will not sign the kernel modules"
+fi
+
+WHICH_MOD="kvm_intel"
+WHICH_KO="kvm-intel.ko"
+if grep -iq "amd" /proc/cpuinfo; then
+    WHICH_MOD="kvm_amd"
+    WHICH_KO="kvm-amd.ko"
 fi
 
 pushd "${KERNEL_SRC}" || { echo "Failed to change directory to ${KERNEL_SRC}"; exit 1; }
@@ -41,16 +55,20 @@ make olddefconfig scripts prepare modules_prepare || { echo "Kernel preparation 
 make M=arch/x86/kvm/ clean
 make M=arch/x86/kvm/ KCPPFLAGS="-DKVM_INTROVIRT_TRACE_EVENTS=${_KVM_INTROVIRT_TRACE_EVENTS}" || { echo "KVM module build failed"; exit 1; }
 
-echo "Signing"
-objcopy --remove-section .BTF ./arch/x86/kvm/kvm.ko
-objcopy --remove-section .BTF ./arch/x86/kvm/kvm-intel.ko
+if [[ -n "${SIGNING_KEY_DIR}" ]]; then
+    echo "Signing"
+    objcopy --remove-section .BTF ./arch/x86/kvm/kvm.ko
+    objcopy --remove-section .BTF ./arch/x86/kvm/kvm-intel.ko
+    objcopy --remove-section .BTF ./arch/x86/kvm/kvm-amd.ko
 
-./scripts/sign-file sha256 "${SIGNING_KEY_DIR}/MOK.priv" "${SIGNING_KEY_DIR}/MOK.der" ./arch/x86/kvm/kvm-intel.ko
-./scripts/sign-file sha256 "${SIGNING_KEY_DIR}/MOK.priv" "${SIGNING_KEY_DIR}/MOK.der" ./arch/x86/kvm/kvm.ko
+    ./scripts/sign-file sha256 "${SIGNING_KEY_DIR}/MOK.priv" "${SIGNING_KEY_DIR}/MOK.der" ./arch/x86/kvm/kvm-intel.ko
+    ./scripts/sign-file sha256 "${SIGNING_KEY_DIR}/MOK.priv" "${SIGNING_KEY_DIR}/MOK.der" ./arch/x86/kvm/kvm.ko
+    ./scripts/sign-file sha256 "${SIGNING_KEY_DIR}/MOK.priv" "${SIGNING_KEY_DIR}/MOK.der" ./arch/x86/kvm/kvm-amd.ko
+fi
 
-sudo rmmod kvm_intel kvm || echo "Modules not loaded, skipping rmmod"
+sudo rmmod ${WHICH_MOD} kvm || echo "Modules not loaded, skipping rmmod"
 sudo insmod ./arch/x86/kvm/kvm.ko || { echo "Failed to insert kvm.ko"; exit 1; }
-sudo insmod ./arch/x86/kvm/kvm-intel.ko || { echo "Failed to insert kvm-intel.ko"; exit 1; }
+sudo insmod ./arch/x86/kvm/${WHICH_KO} || { echo "Failed to insert ${WHICH_KO}"; exit 1; }
 popd || { echo "Failed to return to previous directory"; exit 1; }
 
 echo "KVM kernel modules inserted successfully"

--- a/ubuntu/noble/hwe/6.17.0-35-generic/patches/kvm-introvirt-hwe-6.17.0-35-generic
+++ b/ubuntu/noble/hwe/6.17.0-35-generic/patches/kvm-introvirt-hwe-6.17.0-35-generic
@@ -593,7 +593,7 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/x86.c
  	default:
  		break;
  	}
-@@ -5927,6 +5944,26 @@ static int kvm_vcpu_ioctl_enable_cap(str
+@@ -5927,6 +5944,27 @@ static int kvm_vcpu_ioctl_enable_cap(str
  	}
  }
  
@@ -611,8 +611,9 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/x86.c
 +	// Update MSR_IA32_SYSENTER_CS
 +	kvm_set_msr(vcpu, MSR_IA32_SYSENTER_CS, vcpu->shadow_msr_ia32_sysenter_cs);
 +
-+	// Turn on or off #GP intercept
++	// Turn on or off #UD/#GP intercept and SYSENTER_CS MSR intercept
 +	kvm_x86_ops.update_syscall_intercept(vcpu);
++	kvm_x86_call(recalc_msr_intercepts)(vcpu);
 +done:
 +	return rc;
 +}
@@ -620,7 +621,7 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/x86.c
  long kvm_arch_vcpu_ioctl(struct file *filp,
  			 unsigned int ioctl, unsigned long arg)
  {
-@@ -6390,6 +6427,107 @@ long kvm_arch_vcpu_ioctl(struct file *fi
+@@ -6390,6 +6428,107 @@ long kvm_arch_vcpu_ioctl(struct file *fi
  			goto out;
  		r = kvm_x86_ops.vcpu_mem_enc_ioctl(vcpu, argp);
  		break;
@@ -728,7 +729,7 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/x86.c
  	default:
  		r = -EINVAL;
  	}
-@@ -7305,6 +7443,115 @@ set_pit2_out:
+@@ -7305,6 +7444,115 @@ set_pit2_out:
  		r = kvm_vm_ioctl_set_msr_filter(kvm, &filter);
  		break;
  	}
@@ -844,7 +845,7 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/x86.c
  	default:
  		r = -ENOTTY;
  	}
-@@ -9067,6 +9314,8 @@ int x86_emulate_instruction(struct kvm_v
+@@ -9067,6 +9315,8 @@ int x86_emulate_instruction(struct kvm_v
  	int r;
  	struct x86_emulate_ctxt *ctxt = vcpu->arch.emulate_ctxt;
  	bool writeback = true;
@@ -853,7 +854,7 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/x86.c
  
  	if ((emulation_type & EMULTYPE_ALLOW_RETRY_PF) &&
  	    (WARN_ON_ONCE(is_guest_mode(vcpu)) ||
-@@ -9131,10 +9380,54 @@ int x86_emulate_instruction(struct kvm_v
+@@ -9131,10 +9381,54 @@ int x86_emulate_instruction(struct kvm_v
  		}
  	}
  
@@ -912,7 +913,7 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/x86.c
  	}
  
  	/*
-@@ -9280,6 +9573,11 @@ writeback:
+@@ -9280,6 +9574,11 @@ writeback:
  	} else
  		vcpu->arch.emulate_regs_need_sync_to_vcpu = true;
  
@@ -924,7 +925,7 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/x86.c
  	return r;
  }
  
-@@ -10109,6 +10407,28 @@ EXPORT_SYMBOL_GPL(____kvm_emulate_hyperc
+@@ -10109,6 +10408,28 @@ EXPORT_SYMBOL_GPL(____kvm_emulate_hyperc
  
  int kvm_emulate_hypercall(struct kvm_vcpu *vcpu)
  {
@@ -953,7 +954,7 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/x86.c
  	if (kvm_xen_hypercall_enabled(vcpu->kvm))
  		return kvm_xen_hypercall(vcpu);
  
-@@ -11294,6 +11614,26 @@ static int vcpu_run(struct kvm_vcpu *vcp
+@@ -11294,6 +11615,26 @@ static int vcpu_run(struct kvm_vcpu *vcp
  			r = vcpu_block(vcpu);
  		}
  
@@ -980,7 +981,7 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/x86.c
  		if (r <= 0)
  			break;
  
-@@ -11324,6 +11664,47 @@ static int vcpu_run(struct kvm_vcpu *vcp
+@@ -11324,6 +11665,47 @@ static int vcpu_run(struct kvm_vcpu *vcp
  	return r;
  }
  
@@ -1028,7 +1029,7 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/x86.c
  static int __kvm_emulate_halt(struct kvm_vcpu *vcpu, int state, int reason)
  {
  	/*
-@@ -11982,6 +12363,12 @@ static int __set_sregs_common(struct kvm
+@@ -11982,6 +12364,12 @@ static int __set_sregs_common(struct kvm
  	*mmu_reset_needed |= kvm_read_cr0(vcpu) != sregs->cr0;
  	kvm_x86_call(set_cr0)(vcpu, sregs->cr0);
  
@@ -1041,7 +1042,7 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/x86.c
  	*mmu_reset_needed |= kvm_read_cr4(vcpu) != sregs->cr4;
  	kvm_x86_call(set_cr4)(vcpu, sregs->cr4);
  
-@@ -13631,6 +14018,257 @@ int kvm_spec_ctrl_test_value(u64 value)
+@@ -13631,6 +14019,257 @@ int kvm_spec_ctrl_test_value(u64 value)
  }
  EXPORT_SYMBOL_GPL(kvm_spec_ctrl_test_value);
  
@@ -2294,29 +2295,73 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/svm/svm.c
  	svm->vmcb->save.efer = efer | EFER_SVME;
  	vmcb_mark_dirty(svm->vmcb, VMCB_CR);
  	return 0;
-@@ -1847,6 +1851,46 @@ static void svm_update_exception_bitmap(
+@@ -792,7 +796,9 @@ static void svm_recalc_msr_intercepts(st
+ 	struct vcpu_svm *svm = to_svm(vcpu);
+ 
+ 	svm_disable_intercept_for_msr(vcpu, MSR_STAR, MSR_TYPE_RW);
+-	svm_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_CS, MSR_TYPE_RW);
++	/* IntroVirt: intercept SYSENTER_CS when syscall hook enabled (shadow in __kvm_set_msr) */
++	if (!vcpu->syscall_hook_enabled)
++		svm_disable_intercept_for_msr(vcpu, MSR_IA32_SYSENTER_CS, MSR_TYPE_RW);
+ 
+ #ifdef CONFIG_X86_64
+ 	svm_disable_intercept_for_msr(vcpu, MSR_GS_BASE, MSR_TYPE_RW);
+@@ -1847,6 +1853,79 @@ static void svm_update_exception_bitmap(
  	}
  }
  
-+/* IntroVirt: syscall hook uses #UD (EFER.SCE hidden in svm_set_efer); ensure #UD is intercepted when enabled */
++/* IntroVirt: syscall hook uses #UD (EFER.SCE hidden in svm_set_efer); ensure #UD/#GP are intercepted when enabled */
 +static void svm_update_syscall_intercept(struct kvm_vcpu *vcpu)
 +{
 +	struct vcpu_svm *svm = to_svm(vcpu);
 +
-+	if (vcpu->syscall_hook_enabled)
++	if (vcpu->syscall_hook_enabled) {
 +		set_exception_intercept(svm, UD_VECTOR);
-+	/* when disabled, leave UD as per init (already set) so normal #UD still exits */
++		set_exception_intercept(svm, GP_VECTOR);
++	}
 +	vmcb_mark_dirty(svm->vmcb, VMCB_INTERCEPTS);
 +}
 +
-+/* IntroVirt stubs (AMD: no CR/MTF/INVLPG/memory-feature support; syscall only) */
 +static int svm_set_cr_monitor(struct kvm_vcpu *vcpu, int cr, int mode)
 +{
-+	(void)vcpu;
-+	(void)cr;
-+	(void)mode;
++	struct vcpu_svm *svm = to_svm(vcpu);
++
++	if (unlikely(mode > 0x3))
++		return -EINVAL;
++
++	switch (cr) {
++	case 0:
++	case 4:
++		if (mode & KVM_MONITOR_CR_READ)
++			return -ENODEV;
++		break;
++	case 3:
++		svm_clr_intercept(svm, INTERCEPT_CR3_READ);
++		svm_clr_intercept(svm, INTERCEPT_CR3_WRITE);
++		if (mode & KVM_MONITOR_CR_WRITE)
++			svm_set_intercept(svm, INTERCEPT_CR3_WRITE);
++		if (mode & KVM_MONITOR_CR_READ)
++			svm_set_intercept(svm, INTERCEPT_CR3_READ);
++		break;
++	case 8:
++		svm_clr_intercept(svm, INTERCEPT_CR8_READ);
++		svm_clr_intercept(svm, INTERCEPT_CR8_WRITE);
++		if (mode & KVM_MONITOR_CR_WRITE)
++			svm_set_intercept(svm, INTERCEPT_CR8_WRITE);
++		if (mode & KVM_MONITOR_CR_READ)
++			svm_set_intercept(svm, INTERCEPT_CR8_READ);
++		break;
++	default:
++		return -ENODEV;
++	}
++
++	vcpu->cr_monitor_mask &= ~(0x3 << (cr * 2));
++	vcpu->cr_monitor_mask |= (mode << (cr * 2));
++	vmcb_mark_dirty(svm->vmcb, VMCB_INTERCEPTS);
 +	return 0;
 +}
++
++/* IntroVirt stubs (AMD: no MTF/INVLPG/memory-feature support) */
 +
 +static int svm_set_monitor_trap_flag(struct kvm_vcpu *vcpu, bool enabled)
 +{
@@ -2341,7 +2386,55 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/svm/svm.c
  static void new_asid(struct vcpu_svm *svm, struct svm_cpu_data *sd)
  {
  	if (sd->next_asid > sd->max_asid) {
-@@ -2754,7 +2798,8 @@ static int svm_get_msr(struct kvm_vcpu *
+@@ -2265,7 +2344,7 @@ static int gp_interception(struct kvm_vc
+ 	opcode = svm_instr_opcode(vcpu);
+ 
+ 	if (opcode == NONE_SVM_INSTR) {
+-		if (!enable_vmware_backdoor)
++		if (!enable_vmware_backdoor && !vcpu->syscall_hook_enabled)
+ 			goto reinject;
+ 
+ 		/*
+@@ -2534,6 +2613,7 @@ static int cr_interception(struct kvm_vc
+ 		trace_kvm_cr_write(cr, val);
+ 		switch (cr) {
+ 		case 0:
++			kvm_deliver_cr_write_event(vcpu, 0, val);
+ 			if (!check_selective_cr0_intercepted(vcpu, val))
+ 				err = kvm_set_cr0(vcpu, val);
+ 			else
+@@ -2541,12 +2621,15 @@ static int cr_interception(struct kvm_vc
+ 
+ 			break;
+ 		case 3:
++			kvm_deliver_cr_write_event(vcpu, 3, val);
+ 			err = kvm_set_cr3(vcpu, val);
+ 			break;
+ 		case 4:
++			kvm_deliver_cr_write_event(vcpu, 4, val);
+ 			err = kvm_set_cr4(vcpu, val);
+ 			break;
+ 		case 8:
++			kvm_deliver_cr_write_event(vcpu, 8, val);
+ 			err = kvm_set_cr8(vcpu, val);
+ 			break;
+ 		default:
+@@ -2564,12 +2647,14 @@ static int cr_interception(struct kvm_vc
+ 			break;
+ 		case 3:
+ 			val = kvm_read_cr3(vcpu);
++			kvm_deliver_cr_read_event(vcpu, 3, val);
+ 			break;
+ 		case 4:
+ 			val = kvm_read_cr4(vcpu);
+ 			break;
+ 		case 8:
+ 			val = kvm_get_cr8(vcpu);
++			kvm_deliver_cr_read_event(vcpu, 8, val);
+ 			break;
+ 		default:
+ 			WARN(1, "unhandled read from CR%d", cr);
+@@ -2754,7 +2839,8 @@ static int svm_get_msr(struct kvm_vcpu *
  		break;
  #endif
  	case MSR_IA32_SYSENTER_CS:
@@ -2351,7 +2444,7 @@ Index: 6.17.0-35-generic/kernel/arch/x86/kvm/svm/svm.c
  		break;
  	case MSR_IA32_SYSENTER_EIP:
  		msr_info->data = (u32)svm->vmcb01.ptr->save.sysenter_eip;
-@@ -5187,6 +5232,13 @@ static struct kvm_x86_ops svm_x86_ops __
+@@ -5187,6 +5273,13 @@ static struct kvm_x86_ops svm_x86_ops __
  	.gmem_prepare = sev_gmem_prepare,
  	.gmem_invalidate = sev_gmem_invalidate,
  	.private_max_mapping_level = sev_private_max_mapping_level,


### PR DESCRIPTION
closes #14 

AMD should have always been working with system call monitoring but we were missing some needed functionality in the kernel patch to support guest OS detection.

This fixes the patch so tools like `ivsyscallmon`, `ivfilemon`, `ivguestinfo`, and similar "monitor" tools work.